### PR TITLE
fix: add more allowed fasta file extensions for input file

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -27,3 +27,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 ## List of Contributors
 
 - Sebastian Franz <sebastian.franz@tum.de>
+- Aeneas Tews <aeneas.tews@tum.de>

--- a/lib/plugins/proteins/presentation/commands/protein_load_commands_display.dart
+++ b/lib/plugins/proteins/presentation/commands/protein_load_commands_display.dart
@@ -54,7 +54,7 @@ class _ProteinLoadCommandDisplayState extends State<ProteinLoadCommandDisplay> {
         children: [
           BiocentralFilePathSelection(
             defaultName: _result?.name ?? '/path/to/fasta',
-            allowedExtensions: ['fasta'],
+            allowedExtensions: ['fasta', 'faa', 'fa', 'fas', 'fsa'],
             fileSelectedCallback: (xFile, path) => setState(() {
               _result = xFile;
             }),


### PR DESCRIPTION
fasta file esions are not clearly defined and more extensions thant .fasta are in use. in use. adding these allows morextensions to be seamlesto biocentral without having to rename the file extension.

purposely did not include fna and other extensions specifically targeting nucleotide sequences