### PR TITLE
ability to select which active learning campaign the user would like to view in campaign overview

### DIFF
--- a/lib/plugins/active_learning/bloc/al_hub_bloc.dart
+++ b/lib/plugins/active_learning/bloc/al_hub_bloc.dart
@@ -2,6 +2,7 @@ import 'package:biocentral/plugins/active_learning/domain/al_repository.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/sdk/biocentral_sdk.dart';
 import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
@@ -13,19 +14,25 @@ final class _ALHubLoadInternalEvent extends ALHubEvent {
   _ALHubLoadInternalEvent(this.campaigns);
 }
 
+final class ALHubSelectCampaignEvent extends ALHubEvent {
+  final ALCampaign? campaign;
+
+  ALHubSelectCampaignEvent(this.campaign);
+}
 
 @immutable
 final class ALHubState extends Equatable {
   final List<ALCampaign> campaigns;
+  final ALCampaign? selectedCampaign;
 
-  const ALHubState(this.campaigns);
+  const ALHubState(this.campaigns, {this.selectedCampaign});
 
-  const ALHubState.initial() : campaigns = const [];
+  const ALHubState.initial() : campaigns = const [], selectedCampaign = null;
 
-  const ALHubState.loaded(this.campaigns);
+  const ALHubState.loaded(this.campaigns, {this.selectedCampaign});
 
   @override
-  List<Object?> get props => [campaigns];
+  List<Object?> get props => [campaigns, selectedCampaign];
 }
 
 class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
@@ -34,7 +41,19 @@ class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
 
   ALHubBloc(this._projectRepository, this._alRepository) : super(const ALHubState.initial()) {
     on<_ALHubLoadInternalEvent>((event, emit) async {
-      emit(ALHubState.loaded(event.campaigns));
+      if (event.campaigns.isEmpty) {
+        emit(const ALHubState.initial());
+        return;
+      }
+      final selectedName = state.selectedCampaign?.internalName();
+      final selected = selectedName != null
+          ? event.campaigns.firstWhereOrNull((c) => c.internalName() == selectedName) ?? event.campaigns.first
+          : event.campaigns.first;
+      emit(ALHubState.loaded(event.campaigns, selectedCampaign: selected));
+    });
+
+    on<ALHubSelectCampaignEvent>((event, emit) {
+      emit(ALHubState.loaded(state.campaigns, selectedCampaign: event.campaign));
     });
 
     _setupSubscriptions();

--- a/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
@@ -49,7 +49,19 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ALHubBloc, ALHubState>(
+    return BlocConsumer<ALHubBloc, ALHubState>(
+      listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign,
+      listener: (context, state) {
+        setState(() {
+          _selectedCampaign = state.selectedCampaign;
+          _addedData.clear();
+          if (_selectedCampaign != null) {
+            final iterationSuggestions =
+                _selectedCampaign!.iterationResults.lastOrNull?.$2.suggestions.toList() ?? [];
+            _addedData.addEntries(iterationSuggestions.map((suggestion) => MapEntry(suggestion, '')));
+          }
+        });
+      },
       builder: (context, state) {
         final availability = BiocentralCommandAvailability(
           available: state.campaigns.isNotEmpty,

--- a/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
@@ -73,7 +73,13 @@ class _ALIterationCommandDisplayState extends State<ALIterationCommandDisplay> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ALHubBloc, ALHubState>(
+    return BlocConsumer<ALHubBloc, ALHubState>(
+      listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign,
+      listener: (context, state) {
+        setState(() {
+          _selectedCampaign = state.selectedCampaign;
+        });
+      },
       builder: (context, state) {
         final availability = BiocentralCommandAvailability(
           available: state.campaigns.isNotEmpty,

--- a/lib/plugins/active_learning/presentation/commands/new_al_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/new_al_campaign_command_display.dart
@@ -25,7 +25,7 @@ class NewALCampaignCommandDisplay extends StatefulWidget {
 class _NewALCampaignCommandDisplayState extends State<NewALCampaignCommandDisplay> {
   final Set<BiocentralDatabaseColumn> _availableFeatureColumns = {}; // Need to be partially unlabeled
 
-  String? _campaignName = 'AL-Campaign'; // TODO
+  String _campaignName = 'AL-Campaign';
   Type? _selectedDatabaseType = Protein;
 
   // TODO Maybe refactor to separate campaign config selection
@@ -144,6 +144,7 @@ class _NewALCampaignCommandDisplayState extends State<NewALCampaignCommandDispla
       padding: const EdgeInsets.all(16.0),
       child: Column(
         children: [
+          withCondition(condition: true, childFunction: buildCampaignNameInput),
           withCondition(condition: true, childFunction: buildDatasetSelection),
           withCondition(condition: _selectedDatabaseType != null, childFunction: buildOptimizationModeSelection),
           withCondition(condition: _selectedOptimizationMode != null, childFunction: buildFeatureSelection),
@@ -162,6 +163,21 @@ class _NewALCampaignCommandDisplayState extends State<NewALCampaignCommandDispla
         ),
       ),
     );
+  }
+
+  Widget buildCampaignNameInput() {
+    return TextFormField(
+          initialValue: _campaignName,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Campaign name',
+          ),
+          onChanged: (value) {
+            setState(() {
+              _campaignName = value.trim().isEmpty ? 'AL-Campaign' : value.trim();
+            });
+          },
+        );
   }
 
   Widget buildDatasetSelection() {

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -21,26 +21,51 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return BlocBuilder<ALHubBloc, ALHubState>(
+    return BlocConsumer<ALHubBloc, ALHubState>(
+      listenWhen: (previous, current) =>
+          previous.selectedCampaign?.internalName() != current.selectedCampaign?.internalName(),
+      listener: (context, state) {
+        setState(() {
+          _selectedResultIndex = 0;
+        });
+      },
       builder: (context, hubState) {
         return Scaffold(
           body: SingleChildScrollView(
-            child: buildResult(hubState),
+            child: buildContent(hubState),
           ),
         );
       },
     );
   }
 
-  Widget buildResult(ALHubState hubState) {
+  Widget buildContent(ALHubState hubState) {
     if (hubState.campaigns.isEmpty) {
       return const Center(child: Text('No active learning campaigns yet!'));
     }
-    // TODO Make campaign selectable
-    final campaign = hubState.campaigns.first;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: BiocentralDiscreteSelection<ALCampaign>(
+            title: 'Select Campaign',
+            initialValue: hubState.selectedCampaign,
+            selectableValues: hubState.campaigns,
+            displayConversion: (campaign) => campaign.config.name,
+            onChangedCallback: (campaign) =>
+                context.read<ALHubBloc>().add(ALHubSelectCampaignEvent(campaign)),
+          ),
+        ),
+        if (hubState.selectedCampaign != null) buildResult(hubState.selectedCampaign!),
+      ],
+    );
+  }
+
+  Widget buildResult(ALCampaign campaign) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final widgetWidth = (constraints.maxWidth * 0.8); // 90% of available width
+        final widgetWidth = constraints.maxWidth * 0.8; // 90% of available width
         final widgetHeight = widgetWidth * 0.4; // Maintain aspect ratio
         final totalIterations = campaign.iterationResults.length;
         if (totalIterations == 0) {
@@ -55,24 +80,12 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
               children: [
                 IconButton(
                   icon: const Icon(Icons.arrow_left),
-                  onPressed: _selectedResultIndex > 0
-                      ? () {
-                          setState(() {
-                            _selectedResultIndex--;
-                          });
-                        }
-                      : null,
+                  onPressed: _selectedResultIndex > 0 ? () => setState(() => _selectedResultIndex--) : null,
                 ),
                 Text('Results for iteration: ${_selectedResultIndex + 1}'),
                 IconButton(
                   icon: const Icon(Icons.arrow_right),
-                  onPressed: _selectedResultIndex < totalIterations - 1
-                      ? () {
-                          setState(() {
-                            _selectedResultIndex++;
-                          });
-                        }
-                      : null,
+                  onPressed: _selectedResultIndex < totalIterations - 1  ? () => setState(() => _selectedResultIndex++) : null,
                 ),
               ],
             ),


### PR DESCRIPTION
added discrete selection to al overview to view different active learning campaigns. added state to al_hub_bloc which tracks currently selected campaign. added text input at beginning of campaign creation to give custom names to active learning campaigns. addition of experimental data is configured to use currently selected global active learning campaign, however it can also add data to any campaign