### PR TITLE
Iteration Results, Campaign I/O, and Dataset Change detection

### DIFF
--- a/lib/plugins/active_learning/active_learning_plugin.dart
+++ b/lib/plugins/active_learning/active_learning_plugin.dart
@@ -3,6 +3,8 @@ import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/domain/al_repository.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart';
+import 'package:biocentral/plugins/active_learning/presentation/commands/al_export_campaign_command_display.dart';
+import 'package:biocentral/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart';
 import 'package:biocentral/plugins/active_learning/presentation/commands/al_iteration_command_display.dart';
 import 'package:biocentral/plugins/active_learning/presentation/commands/new_al_campaign_command_display.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_hub_view.dart';
@@ -31,7 +33,7 @@ class ALPlugin extends BiocentralPlugin
 
   @override
   ALRepository createListeningDatabase(
-      BiocentralProjectRepository projectRepository, BiocentralPythonCompanion companion) {
+      BiocentralProjectRepository projectRepository, BiocentralPythonCompanion companion,) {
     final repository = ALRepository(projectRepository);
     return repository;
   }
@@ -41,7 +43,9 @@ class ALPlugin extends BiocentralPlugin
     return [
       const NewALCampaignCommandDisplay(),
       const AddExperimentalDataCommandDisplay(),
-      const ALIterationCommandDisplay()
+      const ALIterationCommandDisplay(),
+      const ALExportCampaignCommandDisplay(),
+      const ALImportCampaignCommandDisplay(),
     ];
   }
 

--- a/lib/plugins/active_learning/bloc/al_commands.dart
+++ b/lib/plugins/active_learning/bloc/al_commands.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/domain/al_repository.dart';
@@ -232,9 +231,9 @@ final class ALExportCampaignCommand extends BiocentralCommand<String> {
     BiocentralCommandLog<String> log = initLog();
     yield log = log.logInfo(information: 'Exporting campaign "${_campaign.config.name}"...');
 
-    final ioFile = io.File(_filePath);
-    final dirPath = ioFile.parent.path;
-    final fileName = ioFile.uri.pathSegments.last;
+    final xFile = XFile(_filePath);
+    final fileName = xFile.name;
+    final dirPath = _filePath.substring(0, _filePath.length - fileName.length - 1);
 
     final saveEither = await _projectRepository.handleExternalSave(
       fileName: fileName,

--- a/lib/plugins/active_learning/bloc/al_commands.dart
+++ b/lib/plugins/active_learning/bloc/al_commands.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' as io;
 
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/domain/al_repository.dart';
@@ -213,4 +214,59 @@ final class ALAddExperimentalDataCommand extends BiocentralCommand<BiocentralDat
 
   @override
   String get typeName => 'ALAddExperimentalDataCommand';
+}
+
+final class ALExportCampaignCommand extends BiocentralCommand<String> {
+  final BiocentralProjectRepository _projectRepository;
+  final ALCampaign _campaign;
+  final String _filePath;
+
+  ALExportCampaignCommand({
+    required BiocentralProjectRepository projectRepository,
+    required ALCampaign campaign,
+    required String filePath,
+  })  : _projectRepository = projectRepository, _campaign = campaign, _filePath = filePath;
+
+  @override
+  Stream<BiocentralCommandLog<String>> execute() async* {
+    BiocentralCommandLog<String> log = initLog();
+    yield log = log.logInfo(information: 'Exporting campaign "${_campaign.config.name}"...');
+
+    final ioFile = io.File(_filePath);
+    final dirPath = ioFile.parent.path;
+    final fileName = ioFile.uri.pathSegments.last;
+
+    final saveEither = await _projectRepository.handleExternalSave(
+      fileName: fileName,
+      contentFunction: () async => jsonEncode({'campaigns': [_campaign.serialize()]}),
+      dirPath: dirPath,
+    );
+    yield saveEither.match(
+      (l) => log.errored(error: l.message),
+      (r) => log.finish(
+        result: BiocentralCommandResult(r ?? '', {'filePath': r ?? ''}),
+        finalProgress: BiocentralCommandProgress(
+          information: 'Campaign "${_campaign.config.name}" exported to $r!',
+          current: 1,
+          total: 1,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void acceptResult(BiocentralCommandLog? resultLog) {
+    // Export has no side effects on the repository
+  }
+
+  @override
+  Map<String, dynamic> getConfigMap() {
+    return {
+      'campaignName': _campaign.config.name,
+      'filePath': _filePath,
+    };
+  }
+
+  @override
+  String get typeName => 'ALExportCampaignCommand';
 }

--- a/lib/plugins/active_learning/bloc/al_hub_bloc.dart
+++ b/lib/plugins/active_learning/bloc/al_hub_bloc.dart
@@ -27,24 +27,42 @@ final class _ALHubProteinUpdateInternalEvent extends ALHubEvent {
   _ALHubProteinUpdateInternalEvent({required this.proteinDatabase});
 }
 
+enum ALDatasetChangeStatus {
+  none,
+  suggestionsMissing,
+  columnMissing,
+}
+
 final class ALHubState extends Equatable {
   final List<ALCampaign> campaigns;
   final ALCampaign? selectedCampaign;
   final Map<String, Protein> proteinDatabase;
-  // Snapshot of selected campaign's iteration count at state-creation time.
-  // ALCampaign is mutable, so including its reference in props would always
-  // compare as equal after an in-place mutation. This int is captured once and
-  // lets Equatable detect that iteration results were added.
+  final ALDatasetChangeStatus datasetChangeStatus;
   final int _selectedCampaignIterationCount;
 
-  ALHubState({required this.campaigns, required this.proteinDatabase, this.selectedCampaign}) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
+  ALHubState({
+    required this.campaigns, 
+    required this.proteinDatabase, 
+    this.selectedCampaign, 
+    this.datasetChangeStatus = ALDatasetChangeStatus.none,})
+      : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
 
-  ALHubState.initial() : campaigns = const [], proteinDatabase = const <String, Protein>{}, selectedCampaign = null, _selectedCampaignIterationCount = 0;
+  ALHubState.initial():
+        campaigns = const [], 
+        proteinDatabase = const <String, Protein>{}, 
+        selectedCampaign = null, 
+        _selectedCampaignIterationCount = 0,
+        datasetChangeStatus = ALDatasetChangeStatus.none;
 
-  ALHubState.loaded({required this.campaigns, required this.proteinDatabase, this.selectedCampaign}) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
+  ALHubState.loaded({
+    required this.campaigns,
+    required this.proteinDatabase,
+    this.selectedCampaign,
+    this.datasetChangeStatus = ALDatasetChangeStatus.none,
+  }) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
 
   @override
-  List<Object?> get props => [campaigns, proteinDatabase, selectedCampaign, _selectedCampaignIterationCount];
+  List<Object?> get props => [campaigns, proteinDatabase, selectedCampaign, _selectedCampaignIterationCount, datasetChangeStatus];
 }
 
 class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
@@ -66,18 +84,49 @@ class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
           ? event.campaigns.firstWhereOrNull((c) => c.internalName() == selectedName) ?? event.campaigns.first
           : event.campaigns.first;
 
-      emit(ALHubState.loaded(campaigns: event.campaigns, proteinDatabase: state.proteinDatabase, selectedCampaign: selected));
+      emit(ALHubState.loaded(
+        campaigns: event.campaigns,
+        proteinDatabase: state.proteinDatabase,
+        selectedCampaign: selected,
+        datasetChangeStatus: _detectDatasetChange(selected, state.proteinDatabase),
+      ),);
     });
 
     on<_ALHubProteinUpdateInternalEvent>((event, emit) async {
-      emit(ALHubState.loaded(campaigns: state.campaigns, proteinDatabase: event.proteinDatabase, selectedCampaign: state.selectedCampaign));
+      emit(ALHubState.loaded(
+        campaigns: state.campaigns,
+        proteinDatabase: event.proteinDatabase,
+        selectedCampaign: state.selectedCampaign,
+        datasetChangeStatus: _detectDatasetChange(state.selectedCampaign, event.proteinDatabase),
+      ),);
     });
 
     on<ALHubSelectCampaignEvent>((event, emit) {
-      emit(ALHubState.loaded(campaigns: state.campaigns, selectedCampaign: event.campaign, proteinDatabase: state.proteinDatabase));
+      emit(ALHubState.loaded(
+        campaigns: state.campaigns,
+        selectedCampaign: event.campaign,
+        proteinDatabase: state.proteinDatabase,
+        datasetChangeStatus: _detectDatasetChange(event.campaign, state.proteinDatabase),
+      ),);
     });
 
     _setupSubscriptions();
+  }
+
+  static ALDatasetChangeStatus _detectDatasetChange(ALCampaign? campaign, Map<String, Protein> database) {
+    if (campaign == null || campaign.iterationResults.isEmpty || database.isEmpty) {
+      return ALDatasetChangeStatus.none;
+    }
+
+    final columnExists = database.values.any((p) => p.attributes.containsKey(campaign.columnName));
+    if (!columnExists) return ALDatasetChangeStatus.columnMissing;
+
+    final lastSuggestions = campaign.iterationResults.last.$2.suggestions.toSet();
+    if (lastSuggestions.isNotEmpty && lastSuggestions.any((id) => !database.containsKey(id))) {
+      return ALDatasetChangeStatus.suggestionsMissing;
+    }
+
+    return ALDatasetChangeStatus.none;
   }
 
   void _setupSubscriptions() {

--- a/lib/plugins/active_learning/bloc/al_hub_bloc.dart
+++ b/lib/plugins/active_learning/bloc/al_hub_bloc.dart
@@ -6,7 +6,6 @@ import 'package:biocentral/sdk/biocentral_sdk.dart';
 import 'package:bloc/bloc.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter/foundation.dart';
 
 sealed class ALHubEvent {}
 
@@ -28,20 +27,24 @@ final class _ALHubProteinUpdateInternalEvent extends ALHubEvent {
   _ALHubProteinUpdateInternalEvent({required this.proteinDatabase});
 }
 
-@immutable
 final class ALHubState extends Equatable {
   final List<ALCampaign> campaigns;
   final ALCampaign? selectedCampaign;
   final Map<String, Protein> proteinDatabase;
+  // Snapshot of selected campaign's iteration count at state-creation time.
+  // ALCampaign is mutable, so including its reference in props would always
+  // compare as equal after an in-place mutation. This int is captured once and
+  // lets Equatable detect that iteration results were added.
+  final int _selectedCampaignIterationCount;
 
-  const ALHubState({required this.campaigns, required this.proteinDatabase, this.selectedCampaign});
+  ALHubState({required this.campaigns, required this.proteinDatabase, this.selectedCampaign}) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
 
-  const ALHubState.initial() : campaigns = const [], proteinDatabase = const <String, Protein>{}, selectedCampaign = null;
+  ALHubState.initial() : campaigns = const [], proteinDatabase = const <String, Protein>{}, selectedCampaign = null, _selectedCampaignIterationCount = 0;
 
-  const ALHubState.loaded({required this.campaigns, required this.proteinDatabase, this.selectedCampaign});
+  ALHubState.loaded({required this.campaigns, required this.proteinDatabase, this.selectedCampaign}) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
 
   @override
-  List<Object?> get props => [campaigns, proteinDatabase, selectedCampaign];
+  List<Object?> get props => [campaigns, proteinDatabase, selectedCampaign, _selectedCampaignIterationCount];
 }
 
 class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
@@ -51,11 +54,10 @@ class ALHubBloc extends Bloc<ALHubEvent, ALHubState> {
 
   ALHubBloc(this._projectRepository, this._alRepository, ProteinRepository _proteinRepository)
       : _proteinRepository = _proteinRepository,
-        super(ALHubState(campaigns: const [],
-          proteinDatabase: _proteinRepository.databaseToMap(),),) {
+        super(ALHubState(campaigns: const [], proteinDatabase: _proteinRepository.databaseToMap())) {
     on<_ALHubLoadInternalEvent>((event, emit) async {
       if (event.campaigns.isEmpty) {
-        emit(const ALHubState.initial());
+        emit(ALHubState.initial());
         return;
       }
 

--- a/lib/plugins/active_learning/bloc/al_hub_bloc.dart
+++ b/lib/plugins/active_learning/bloc/al_hub_bloc.dart
@@ -61,6 +61,8 @@ final class ALHubState extends Equatable {
     this.datasetChangeStatus = ALDatasetChangeStatus.none,
   }) : _selectedCampaignIterationCount = selectedCampaign?.iterationResults.length ?? 0;
 
+  int get selectedCampaignIterationCount => _selectedCampaignIterationCount;
+
   @override
   List<Object?> get props => [campaigns, proteinDatabase, selectedCampaign, _selectedCampaignIterationCount, datasetChangeStatus];
 }

--- a/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
@@ -8,7 +8,6 @@ import 'package:biocentral/sdk/presentation/widgets/biocentral_command_widget.da
 import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:fpdart/fpdart.dart' show FpdartOnIterable;
 
 class AddExperimentalDataCommandDisplay extends StatefulWidget {
   const AddExperimentalDataCommandDisplay({super.key});
@@ -22,18 +21,43 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
 
   ALCampaign? _selectedCampaign;
 
+  // Suggested sequence IDs (from latest iteration suggestions)
   final Map<String, String> _addedData = {};
+  // Extra sequence IDs (user-staged, not in suggestions)
+  final Map<String, String> _extraData = {};
+
+  // State for pending extra-entry row
+  String? _pendingExtraId;
+  final TextEditingController _extraValueController = TextEditingController();
+  
+  // Changing this key forces BiocentralDiscreteSelection to fully rebuild and clear its internal selection after an entry is staged.
+  Key _dropdownKey = UniqueKey();
 
   @override
-  void initState() {
-    super.initState();
+  void dispose() {
+    _extraValueController.dispose();
+    super.dispose();
+  }
+
+  void _resetCampaignState(ALCampaign? campaign) {
+    _selectedCampaign = campaign;
+    _addedData.clear();
+    _extraData.clear();
+    _pendingExtraId = null;
+    _extraValueController.clear();
+    _dropdownKey = UniqueKey();
+    if (campaign != null) {
+      final suggestions = campaign.iterationResults.lastOrNull?.$2.suggestions.toList() ?? [];
+      _addedData.addEntries(suggestions.map((s) => MapEntry(s, '')));
+    }
   }
 
   ALAddExperimentalDataCommand? collectCommand() {
     final database = context.read<BiocentralDatabaseRepository>().getFromType(_selectedDatabaseType);
+    final merged = {..._addedData, ..._extraData};
     final addedNonEmptyData = <String, String>{};
-    for(final (k, v) in _addedData.entriesRecord) {
-      if(v.isNotEmpty) {
+    for (final (k, v) in merged.entriesRecord) {
+      if (v.isNotEmpty) {
         addedNonEmptyData[k] = v;
       }
     }
@@ -53,13 +77,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
       listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign,
       listener: (context, state) {
         setState(() {
-          _selectedCampaign = state.selectedCampaign;
-          _addedData.clear();
-          if (_selectedCampaign != null) {
-            final iterationSuggestions =
-                _selectedCampaign!.iterationResults.lastOrNull?.$2.suggestions.toList() ?? [];
-            _addedData.addEntries(iterationSuggestions.map((suggestion) => MapEntry(suggestion, '')));
-          }
+          _resetCampaignState(state.selectedCampaign);
         });
       },
       builder: (context, state) {
@@ -72,7 +90,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
           name: 'Add experimental data to campaign',
           description: 'Add experimentally verified data to a running active learning campaign',
           executeButtonLabel: 'Add',
-          parameterSelection: () => buildParameterSelection(state.campaigns),
+          parameterSelection: () => buildParameterSelection(state.campaigns, state.proteinDatabase),
           collectCommand: collectCommand,
           visualizeResult: BiocentralCommandWidget.visualizeDatabaseResult,
           commandAvailability: availability,
@@ -81,7 +99,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
     );
   }
 
-  Widget buildParameterSelection(List<ALCampaign> campaigns) {
+  Widget buildParameterSelection(List<ALCampaign> campaigns, Map<String, Protein> proteinDatabase) {
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Column(
@@ -91,7 +109,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
             condition: _selectedDatabaseType != null,
             childFunction: () => buildCampaignSelection(campaigns),
           ),
-          withCondition(condition: _selectedCampaign != null, childFunction: buildDataInput),
+          withCondition(condition: _selectedCampaign != null, childFunction: () => buildDataInput(proteinDatabase)),
         ].withPadding(
           const Padding(
             padding: EdgeInsetsGeometry.all(8.0),
@@ -131,13 +149,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
           displayConversion: (campaign) => campaign.config.name,
           onChangedCallback: (ALCampaign? selected) {
             setState(() {
-              _selectedCampaign = selected;
-              _addedData.clear();
-              if (_selectedCampaign != null) {
-                final iterationSuggestions =
-                    _selectedCampaign!.iterationResults.lastOrNull?.$2.suggestions.toList() ?? [];
-                _addedData.addEntries(iterationSuggestions.map((suggestion) => MapEntry(suggestion, '')));
-              }
+              _resetCampaignState(selected);
             });
           },
         ),
@@ -145,31 +157,127 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
     );
   }
 
-  Widget buildDataInput() {
+  Widget buildDataInput(Map<String, Protein> proteinDatabase) {
     if (_selectedCampaign == null) {
-      return Container();
+      return const SizedBox.shrink(); // TODO: compare to Container() to see if it makes any difference
     }
     if (_selectedCampaign!.iterationResults.isEmpty) {
       return const Text('Selected campaign does not have any results yet to add data!');
     }
+
+    final suggestionSet = _addedData.keys.toSet();
+    
+    final availableForExtra = proteinDatabase.entries
+        .where((e) {
+          final existing = e.value.attributes[_selectedCampaign!.columnName];
+          final hasData = existing != null && existing.toString().isNotEmpty;
+          return !hasData && !suggestionSet.contains(e.key) && !_extraData.containsKey(e.key);
+        })
+        .map((e) => e.key).toList()..sort();
+
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
       children: [
-        const Text('Input Data'),
-        ..._selectedCampaign!.iterationResults.last.$2.suggestions.map((suggestion) => TextFormField(
+        const Align(
+          alignment: Alignment.centerLeft,
+          child: Text('Suggested sequences'),
+        ),
+        ..._addedData.keys.map((suggestion) => TextFormField(
           decoration: InputDecoration(labelText: suggestion),
           textAlign: TextAlign.center,
           initialValue: _addedData[suggestion],
           autovalidateMode: AutovalidateMode.onUserInteraction,
           // TODO Improve validation
-          validator: (val) => val == null || val.isEmpty ? 'Column name must not be empty!' : null,
+          validator: (val) => val == null || val.isEmpty ? 'Value must not be empty!' : null,
           onChanged: (val) {
             setState(() {
-              _addedData[suggestion] = val.toString();
+              _addedData[suggestion] = val; // TODO: check if val.toString() makes a difference
             });
           },
-        )),
+        ),),
+
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8.0),
+          child: Divider(),
+        ),
+        const Align(
+          alignment: Alignment.centerLeft,
+          child: Text('Add data for other sequences (optional)'),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: BiocentralDiscreteSelection<String>(
+                key: _dropdownKey,
+                title: 'Select sequence',
+                selectableValues: availableForExtra,
+                displayConversion: (id) => id,
+                initialValue: _pendingExtraId,
+                onChangedCallback: (String? selected) {
+                  setState(() {
+                    _pendingExtraId = selected;
+                  });
+                },
+              ),
+            ),
+            const SizedBox(width: 8), // TODO: check if these should be in a single row instead of underneath each other
+            Expanded(
+              child: TextFormField(
+                controller: _extraValueController,
+                decoration: const InputDecoration(labelText: 'Value'),
+                textAlign: TextAlign.center,
+                onChanged: (_) => setState(() {}),
+              ),
+            ),
+            const SizedBox(width: 8),
+            BiocentralSmallButton(
+              label: 'Stage',
+              onTap: _pendingExtraId != null && _extraValueController.text.isNotEmpty ? () {
+                final id = _pendingExtraId!;
+                final value = _extraValueController.text;
+                _extraValueController.clear();
+                setState(() {
+                  _extraData[id] = value;
+                  _pendingExtraId = null;
+                  _dropdownKey = UniqueKey();
+                });
+              } : null,
+            ),
+          ],
+        ),
+        
+        if (_extraData.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          ..._extraData.entries.map((entry) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(entry.key, overflow: TextOverflow.ellipsis),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    entry.value,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: 'Remove',
+                  onPressed: () {
+                    setState(() {
+                      _extraData.remove(entry.key);
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),),
+        ],
       ],
     );
   }

--- a/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
@@ -32,6 +32,9 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
   
   // Changing this key forces BiocentralDiscreteSelection to fully rebuild and clear its internal selection after an entry is staged.
   Key _dropdownKey = UniqueKey();
+  
+  // Changing this key forces all suggestion TextFormFields to rebuild and clear their internal state on campaign/iteration reset.
+  Key _suggestionsAreaKey = UniqueKey();
 
   @override
   void dispose() {
@@ -46,6 +49,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
     _pendingExtraId = null;
     _extraValueController.clear();
     _dropdownKey = UniqueKey();
+    _suggestionsAreaKey = UniqueKey();
     if (campaign != null) {
       final suggestions = campaign.iterationResults.lastOrNull?.$2.suggestions.toList() ?? [];
       _addedData.addEntries(suggestions.map((s) => MapEntry(s, '')));
@@ -74,7 +78,8 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<ALHubBloc, ALHubState>(
-      listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign,
+      listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign
+          || previous.selectedCampaignIterationCount != current.selectedCampaignIterationCount,
       listener: (context, state) {
         setState(() {
           _resetCampaignState(state.selectedCampaign);
@@ -183,19 +188,25 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
           alignment: Alignment.centerLeft,
           child: Text('Suggested sequences'),
         ),
-        ..._addedData.keys.map((suggestion) => TextFormField(
-          decoration: InputDecoration(labelText: suggestion),
-          textAlign: TextAlign.center,
-          initialValue: _addedData[suggestion],
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          // TODO Improve validation
-          validator: (val) => val == null || val.isEmpty ? 'Value must not be empty!' : null,
-          onChanged: (val) {
-            setState(() {
-              _addedData[suggestion] = val;
-            });
-          },
-        ),),
+        KeyedSubtree(
+          key: _suggestionsAreaKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: _addedData.keys.map((suggestion) => TextFormField(
+              decoration: InputDecoration(labelText: suggestion),
+              textAlign: TextAlign.center,
+              initialValue: _addedData[suggestion],
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              // TODO Improve validation
+              validator: (val) => val == null || val.isEmpty ? 'Value must not be empty!' : null,
+              onChanged: (val) {
+                setState(() {
+                  _addedData[suggestion] = val;
+                });
+              },
+            ),).toList(),
+          ),
+        ),
 
         const Padding(
           padding: EdgeInsets.symmetric(vertical: 8.0),

--- a/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
@@ -159,7 +159,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
 
   Widget buildDataInput(Map<String, Protein> proteinDatabase) {
     if (_selectedCampaign == null) {
-      return const SizedBox.shrink(); // TODO: compare to Container() to see if it makes any difference
+      return Container();
     }
     if (_selectedCampaign!.iterationResults.isEmpty) {
       return const Text('Selected campaign does not have any results yet to add data!');
@@ -192,7 +192,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
           validator: (val) => val == null || val.isEmpty ? 'Value must not be empty!' : null,
           onChanged: (val) {
             setState(() {
-              _addedData[suggestion] = val; // TODO: check if val.toString() makes a difference
+              _addedData[suggestion] = val;
             });
           },
         ),),
@@ -203,78 +203,71 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
         ),
         const Align(
           alignment: Alignment.centerLeft,
-          child: Text('Add data for other sequences (optional)'),
+          child: Text('Other sequences (optional)'),
         ),
         const SizedBox(height: 8),
-        Row(
-          children: [
-            Expanded(
-              child: BiocentralDiscreteSelection<String>(
-                key: _dropdownKey,
-                title: 'Select sequence',
-                selectableValues: availableForExtra,
-                displayConversion: (id) => id,
-                initialValue: _pendingExtraId,
-                onChangedCallback: (String? selected) {
-                  setState(() {
-                    _pendingExtraId = selected;
-                  });
-                },
-              ),
-            ),
-            const SizedBox(width: 8), // TODO: check if these should be in a single row instead of underneath each other
-            Expanded(
-              child: TextFormField(
-                controller: _extraValueController,
-                decoration: const InputDecoration(labelText: 'Value'),
-                textAlign: TextAlign.center,
-                onChanged: (_) => setState(() {}),
-              ),
-            ),
-            const SizedBox(width: 8),
-            BiocentralSmallButton(
-              label: 'Stage',
-              onTap: _pendingExtraId != null && _extraValueController.text.isNotEmpty ? () {
-                final id = _pendingExtraId!;
-                final value = _extraValueController.text;
-                _extraValueController.clear();
-                setState(() {
-                  _extraData[id] = value;
-                  _pendingExtraId = null;
-                  _dropdownKey = UniqueKey();
-                });
-              } : null,
-            ),
-          ],
-        ),
-        
-        if (_extraData.isNotEmpty) ...[
-          const SizedBox(height: 8),
-          ..._extraData.entries.map((entry) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2.0),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(entry.key, overflow: TextOverflow.ellipsis),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    entry.value,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  tooltip: 'Remove',
-                  onPressed: () {
+        if (availableForExtra.isEmpty)
+          const Text('All sequences in the dataset already have data for this column.')
+        else
+          Row(
+            children: [
+              Expanded(
+                child: BiocentralDiscreteSelection<String>(
+                  key: _dropdownKey,
+                  title: 'Select sequence',
+                  selectableValues: availableForExtra,
+                  displayConversion: (id) => id,
+                  initialValue: _pendingExtraId,
+                  onChangedCallback: (String? selected) {
                     setState(() {
-                      _extraData.remove(entry.key);
+                      _pendingExtraId = selected;
                     });
                   },
                 ),
-              ],
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  controller: _extraValueController,
+                  decoration: const InputDecoration(labelText: 'Value'),
+                  textAlign: TextAlign.center,
+                  onChanged: (_) => setState(() {}),
+                ),
+              ),
+              const SizedBox(width: 8),
+              BiocentralSmallButton(
+                label: 'Stage',
+                onTap: _pendingExtraId != null && _extraValueController.text.isNotEmpty ? () {
+                  final id = _pendingExtraId!;
+                  final value = _extraValueController.text;
+                  _extraValueController.clear();
+                  setState(() {
+                    _extraData[id] = value;
+                    _pendingExtraId = null;
+                    _dropdownKey = UniqueKey();
+                  });
+                } : null,
+              ),
+            ],
+          ),
+        
+        if (_extraData.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          ..._extraData.entries.map((entry) => Card(
+            margin: const EdgeInsets.symmetric(vertical: 4.0),
+            child: ListTile(
+              dense: true,
+              title: Text(entry.key, overflow: TextOverflow.ellipsis),
+              subtitle: Text(entry.value, style: Theme.of(context).textTheme.bodyMedium),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Unstage',
+                onPressed: () {
+                  setState(() {
+                    _extraData.remove(entry.key);
+                  });
+                },
+              ),
             ),
           ),),
         ],

--- a/lib/plugins/active_learning/presentation/commands/al_export_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_export_campaign_command_display.dart
@@ -1,0 +1,94 @@
+import 'package:biocentral/plugins/active_learning/bloc/al_commands.dart';
+import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
+import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/biocentral_sdk.dart';
+import 'package:biocentral/sdk/bloc/biocentral_command_availability.dart';
+import 'package:biocentral/sdk/presentation/widgets/biocentral_command_widget.dart';
+import 'package:biocentral/sdk/presentation/widgets/biocentral_file_path_selection.dart';
+import 'package:biocentral/sdk/util/widget_util.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ALExportCampaignCommandDisplay extends StatefulWidget {
+  const ALExportCampaignCommandDisplay({super.key});
+
+  @override
+  State<ALExportCampaignCommandDisplay> createState() => _ALExportCampaignCommandDisplayState();
+}
+
+class _ALExportCampaignCommandDisplayState extends State<ALExportCampaignCommandDisplay> {
+  ALCampaign? _selectedCampaign;
+  String? _exportPath;
+
+  ALExportCampaignCommand? collectCommand() {
+    if (_selectedCampaign != null && _exportPath != null) {
+      return ALExportCampaignCommand(
+        projectRepository: context.read<BiocentralProjectRepository>(),
+        campaign: _selectedCampaign!,
+        filePath: _exportPath!,
+      );
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<ALHubBloc, ALHubState>(
+      listenWhen: (previous, current) => previous.selectedCampaign != current.selectedCampaign,
+      listener: (context, state) {
+        setState(() {
+          _selectedCampaign = state.selectedCampaign;
+          _exportPath = null;
+        });
+      },
+      builder: (context, state) {
+        final availability = BiocentralCommandAvailability(
+          available: state.campaigns.isNotEmpty,
+          unavailableMessage: 'No campaigns available to export!',
+        );
+        return BiocentralCommandWidget(
+          icon: const Icon(Icons.save),
+          name: 'Export campaign',
+          description: 'Save a campaign to a JSON file',
+          executeButtonLabel: 'Export',
+          parameterSelection: () => buildParameterSelection(state.campaigns),
+          collectCommand: collectCommand,
+          visualizeResult: BiocentralCommandWidget.visualizeDatabaseResult,
+          commandAvailability: availability,
+          alwaysAutoAccept: true,
+        );
+      },
+    );
+  }
+
+  Widget buildParameterSelection(List<ALCampaign> campaigns) {
+    final defaultFileName = 'campaign_${_selectedCampaign?.config.name ?? 'export'}.json';
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          BiocentralDiscreteSelection<ALCampaign>(
+            title: 'Campaign to export',
+            selectableValues: campaigns,
+            initialValue: _selectedCampaign,
+            displayConversion: (c) => c.config.name,
+            onChangedCallback: (ALCampaign? selected) {
+              setState(() {
+                _selectedCampaign = selected;
+                _exportPath = null;
+              });
+            },
+          ),
+          BiocentralFilePathSelection(
+            defaultName: _exportPath ?? defaultFileName,
+            allowedExtensions: const ['json'],
+            fileSelectedCallback: (_, path) => setState(() {
+              _exportPath = path;
+            }),
+            pickForExport: true,
+          ),
+        ].withPadding(const Padding(padding: EdgeInsets.all(8.0))),
+      ),
+    );
+  }
+}

--- a/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
@@ -50,7 +50,7 @@ class _ALImportCampaignCommandDisplayState extends State<ALImportCampaignCommand
             child: ListTile(
               leading: Icon(
                 conflicts ? Icons.warning_amber_rounded : Icons.check_circle_outline,
-                color: conflicts ? Colors.orange : Colors.green,
+                color: conflicts ? BiocentralStyle.alWarningColor : BiocentralStyle.alSuccessColor,
               ),
               title: Text(campaign.config.name),
               subtitle: Column(
@@ -60,7 +60,7 @@ class _ALImportCampaignCommandDisplayState extends State<ALImportCampaignCommand
                   const SizedBox(height: 2),
                   Text(
                     conflicts ? 'A campaign with this name already exists and will be overwritten if you proceed!' : 'Campaign can be added without issues.',
-                    style: TextStyle(color: conflicts ? Colors.orange.shade800 : Colors.green.shade700, fontStyle: FontStyle.italic),
+                    style: TextStyle(color: conflicts ? BiocentralStyle.alWarningTextColor : BiocentralStyle.alSuccessTextColor, fontStyle: FontStyle.italic),
                   ),
                 ],
               ),

--- a/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
@@ -1,0 +1,110 @@
+import 'package:biocentral/plugins/active_learning/bloc/al_commands.dart';
+import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
+import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/biocentral_sdk.dart';
+import 'package:biocentral/sdk/bloc/biocentral_command_availability.dart';
+import 'package:biocentral/sdk/presentation/widgets/biocentral_command_widget.dart';
+import 'package:biocentral/sdk/presentation/widgets/biocentral_file_path_selection.dart';
+import 'package:biocentral/sdk/util/widget_util.dart';
+import 'package:cross_file/cross_file.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ALImportCampaignCommandDisplay extends StatefulWidget {
+  const ALImportCampaignCommandDisplay({super.key});
+
+  @override
+  State<ALImportCampaignCommandDisplay> createState() => _ALImportCampaignCommandDisplayState();
+}
+
+class _ALImportCampaignCommandDisplayState extends State<ALImportCampaignCommandDisplay> {
+  XFile? _selectedFile;
+
+  LoadALDatabaseCommand? collectCommand() {
+    if (_selectedFile == null) return null;
+    return LoadALDatabaseCommand(
+      projectRepository: context.read<BiocentralProjectRepository>(),
+      alRepository: context.read(),
+      alDBFile: _selectedFile!,
+      importMode: DatabaseImportMode.overwrite,
+    );
+  }
+
+  Widget _buildImportResult(BiocentralCommandLog log, List<ALCampaign> existingCampaigns) {
+    final loaded = log.result?.result;
+    if (loaded == null || loaded is! List<ALCampaign>) {
+      return BiocentralStatusIndicator(metaData: log.metaData);
+    }
+
+    final existingNames = {for (final campaign in existingCampaigns) campaign.internalName()};
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        BiocentralStatusIndicator(metaData: log.metaData),
+        const SizedBox(height: 8),
+        ...loaded.map((campaign) {
+          final conflicts = existingNames.contains(campaign.internalName());
+          return Card(
+            margin: const EdgeInsets.symmetric(vertical: 4),
+            child: ListTile(
+              leading: Icon(
+                conflicts ? Icons.warning_amber_rounded : Icons.check_circle_outline,
+                color: conflicts ? Colors.orange : Colors.green,
+              ),
+              title: Text(campaign.config.name),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('${campaign.iterationResults.length} iteration(s); column: ${campaign.columnName}'),
+                  const SizedBox(height: 2),
+                  Text(
+                    conflicts ? 'A campaign with this name already exists and will be overwritten if you proceed!' : 'Campaign can be added without issues.',
+                    style: TextStyle(color: conflicts ? Colors.orange.shade800 : Colors.green.shade700, fontStyle: FontStyle.italic),
+                  ),
+                ],
+              ),
+              isThreeLine: true,
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ALHubBloc, ALHubState>(
+      builder: (context, state) {
+        final existingCampaigns = state.campaigns;
+        return BiocentralCommandWidget(
+          icon: const Icon(Icons.file_open),
+          name: 'Import campaign',
+          description: 'Load a previously exported campaign from a JSON file',
+          executeButtonLabel: 'Import',
+          parameterSelection: buildParameterSelection,
+          collectCommand: collectCommand,
+          visualizeResult: (log) => _buildImportResult(log, existingCampaigns),
+          commandAvailability: BiocentralCommandAvailability.always(),
+        );
+      },
+    );
+  }
+
+  Widget buildParameterSelection() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          BiocentralFilePathSelection(
+            defaultName: _selectedFile?.name ?? 'Select campaign JSON file',
+            allowedExtensions: const ['json'],
+            fileSelectedCallback: (xFile, _) => setState(() {
+              _selectedFile = xFile;
+            }),
+          ),
+        ].withPadding(const Padding(padding: EdgeInsets.all(8.0))),
+      ),
+    );
+  }
+}

--- a/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
@@ -11,7 +11,6 @@ import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:fpdart/fpdart.dart' show FpdartOnIterable;
 
 class ALIterationCommandDisplay extends StatefulWidget {
   const ALIterationCommandDisplay({super.key});
@@ -81,9 +80,12 @@ class _ALIterationCommandDisplayState extends State<ALIterationCommandDisplay> {
         });
       },
       builder: (context, state) {
+        final columnMissing = state.datasetChangeStatus == ALDatasetChangeStatus.columnMissing;
         final availability = BiocentralCommandAvailability(
-          available: state.campaigns.isNotEmpty,
-          unavailableMessage: 'No current campaigns to add data to!',
+          available: state.campaigns.isNotEmpty && !columnMissing,
+          unavailableMessage: columnMissing
+              ? 'Campaign column is missing from the loaded dataset. Export the campaign and fix your dataset before running more iterations.'
+              : 'No current campaigns to run iterations for!',
         );
         return BiocentralCommandWidget(
           icon: const Icon(Icons.newspaper),

--- a/lib/plugins/active_learning/presentation/views/al_database_grid_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_database_grid_view.dart
@@ -9,6 +9,7 @@ import 'package:pluto_grid/pluto_grid.dart';
 
 /// A widget that displays Active Learning results in a grid format.
 /// Shows protein sequences, scores, uncertainties, and other metrics in a sortable and filterable table.
+/// When [displayedResult] is null, shows all iterations combined with an Iteration column.
 class ALDatabaseGridView extends StatefulWidget {
   final ALCampaign campaign;
   final ActiveLearningIterationResult? displayedResult;
@@ -67,6 +68,8 @@ class _ALDatabaseGridViewState extends State<ALDatabaseGridView> {
   /// Grid mode configuration
   final PlutoGridMode plutoGridMode = PlutoGridMode.selectWithOneTap;
 
+  bool get _showAllIterations => widget.displayedResult == null;
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ALHubBloc, ALHubState>(
@@ -75,8 +78,8 @@ class _ALDatabaseGridViewState extends State<ALDatabaseGridView> {
         return Scaffold(
           body: LayoutBuilder(
             builder: (context, constraints) {
-              final double columnWidth = (constraints.maxWidth - 100) / _alColumns.length - 1;
-              return _buildGrid(columnWidth, state.proteinDatabase);
+              final columns = buildColumns(constraints.maxWidth);
+              return _buildGrid(columns, state.proteinDatabase);
             },
           ),
         );
@@ -85,32 +88,52 @@ class _ALDatabaseGridViewState extends State<ALDatabaseGridView> {
   }
 
   /// Builds the main grid widget with configured columns and rows
-  Widget _buildGrid(double columnWidth, Map<String, Protein> proteinDatabase) {
+  Widget _buildGrid(List<PlutoColumn> columns, Map<String, Protein> proteinDatabase) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: PlutoGrid(
         key: UniqueKey(),
         mode: plutoGridMode,
-        columns: buildColumns(columnWidth),
-        rows: buildRows(proteinDatabase),
+        columns: columns,
+        rows: _showAllIterations ? buildAllRows(proteinDatabase) : buildRows(proteinDatabase),
       ),
     );
   }
 
-  /// Builds and configures columns with the specified width
-  List<PlutoColumn> buildColumns(double columnWidth) {
+  List<PlutoColumn> buildColumns(double availableWidth) {
+    final allCols = <PlutoColumn>[
+      if (_showAllIterations)
+        PlutoColumn(
+          title: 'Iteration',
+          field: 'iteration',
+          readOnly: true,
+          width: 90,
+          minWidth: 90,
+          type: PlutoColumnType.number(),
+        ),
+      ..._alColumns,
+    ];
+
+    final fixedWidth = _showAllIterations ? 90.0 + 100.0 : 100.0; // iteration col + ranking col
+    final remainingCols = allCols.length - (_showAllIterations ? 2 : 1);
+    final columnWidth = (availableWidth - fixedWidth - 100) / remainingCols - 1;
+
     var index = 0;
-    final List<PlutoColumn> result = List.from(_alColumns);
-    for (PlutoColumn column in result) {
-      if (index++ == 0) {
+    for (final column in allCols) {
+      if (column.field == 'iteration') {
+        index++;
+        continue;
+      }
+      if (index == (_showAllIterations ? 1 : 0)) {
         column.width = 100;
         column.minWidth = 100;
       } else {
         column.width = columnWidth;
         column.minWidth = columnWidth;
       }
+      index++;
     }
-    return result;
+    return allCols;
   }
 
   /// Builds rows from the training results data
@@ -136,5 +159,29 @@ class _ALDatabaseGridViewState extends State<ALDatabaseGridView> {
         },
       );
     }).toList();
+  }
+
+  List<PlutoRow> buildAllRows(Map<String, Protein> proteinDatabase) {
+    final rows = <PlutoRow>[];
+    int index = 0;
+    for (final (_, iterResult) in widget.campaign.iterationResults) {
+      final suggestionSet = iterResult.suggestions.toSet();
+      final suggestions = iterResult.results.where((r) => suggestionSet.contains(r.entityId)).toList();
+      for (final alResult in suggestions) {
+        final experimentalValue = proteinDatabase[alResult.entityId]?.attributes[widget.campaign.columnName];
+        rows.add(PlutoRow(
+          cells: {
+            'iteration': PlutoCell(value: iterResult.iteration),
+            'ranking': PlutoCell(value: ++index),
+            'proteinId': PlutoCell(value: alResult.entityId),
+            'score': PlutoCell(value: alResult.score.toStringAsFixed(Constants.maxDoublePrecision)),
+            'uncertainty': PlutoCell(value: alResult.uncertainty.toStringAsFixed(Constants.maxDoublePrecision)),
+            'prediction': PlutoCell(value: alResult.prediction),
+            'experiment': PlutoCell(value: experimentalValue ?? ''),
+          },
+        ),);
+      }
+    }
+    return rows;
   }
 }

--- a/lib/plugins/active_learning/presentation/views/al_database_grid_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_database_grid_view.dart
@@ -73,7 +73,7 @@ class _ALDatabaseGridViewState extends State<ALDatabaseGridView> {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ALHubBloc, ALHubState>(
-      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase,
+      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase || previous.selectedCampaign != current.selectedCampaign,
       builder: (context, state) {
         return Scaffold(
           body: LayoutBuilder(

--- a/lib/plugins/active_learning/presentation/views/al_hub_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_hub_view.dart
@@ -1,7 +1,9 @@
+import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_iteration_result_view.dart';
 import 'package:biocentral/sdk/presentation/widgets/biocentral_command_view.dart';
 import 'package:biocentral/sdk/util/size_config.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ALHubView extends StatefulWidget {
   final List<Widget> commandWidgets;
@@ -32,6 +34,10 @@ class _ALHubViewState extends State<ALHubView> with AutomaticKeepAliveClientMixi
                 ],
               ),
             ),
+            BlocBuilder<ALHubBloc, ALHubState>(
+              buildWhen: (previous, current) => previous.datasetChangeStatus != current.datasetChangeStatus,
+              builder: (context, state) => _buildDatasetChangeBanner(state),
+            ),
             SizedBox(height: SizeConfig.safeBlockVertical(context) * 2),
             Flexible(
               flex: 5,
@@ -46,6 +52,33 @@ class _ALHubViewState extends State<ALHubView> with AutomaticKeepAliveClientMixi
         ),
       ),
     );
+  }
+
+  Widget _buildDatasetChangeBanner(ALHubState state) {
+    switch (state.datasetChangeStatus) {
+      case ALDatasetChangeStatus.none:
+        return const SizedBox.shrink();
+      case ALDatasetChangeStatus.suggestionsMissing:
+        return MaterialBanner(
+          backgroundColor: Colors.orange.shade100,
+          leading: const Icon(Icons.warning_amber_rounded, color: Colors.orange),
+          content: const Text(
+            'Some suggested proteins from the latest iteration are no longer in the loaded dataset. '
+            'Consider exporting the campaign before making further changes.',
+          ),
+          actions: const [SizedBox.shrink()],
+        );
+      case ALDatasetChangeStatus.columnMissing:
+        return MaterialBanner(
+          backgroundColor: Colors.red.shade100,
+          leading: const Icon(Icons.error_outline, color: Colors.red),
+          content: Text(
+            'The target column "${state.selectedCampaign?.columnName}" no longer exists in the loaded dataset. '
+            'Further iterations are disabled. Export the campaign and fix your dataset before continuing!',
+          ),
+          actions: const [SizedBox.shrink()],
+        );
+    }
   }
 
   @override

--- a/lib/plugins/active_learning/presentation/views/al_hub_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_hub_view.dart
@@ -1,5 +1,6 @@
 import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_iteration_result_view.dart';
+import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/presentation/widgets/biocentral_command_view.dart';
 import 'package:biocentral/sdk/util/size_config.dart';
 import 'package:flutter/material.dart';
@@ -59,19 +60,19 @@ class _ALHubViewState extends State<ALHubView> with AutomaticKeepAliveClientMixi
       case ALDatasetChangeStatus.none:
         return const SizedBox.shrink();
       case ALDatasetChangeStatus.suggestionsMissing:
-        return MaterialBanner(
-          backgroundColor: Colors.orange.shade100,
-          leading: const Icon(Icons.warning_amber_rounded, color: Colors.orange),
-          content: const Text(
+        return const MaterialBanner(
+          backgroundColor: BiocentralStyle.alWarningBackgroundColor,
+          leading: Icon(Icons.warning_amber_rounded, color: BiocentralStyle.alWarningColor),
+          content: Text(
             'Some suggested proteins from the latest iteration are no longer in the loaded dataset. '
             'Consider exporting the campaign before making further changes.',
           ),
-          actions: const [SizedBox.shrink()],
+          actions: [SizedBox.shrink()],
         );
       case ALDatasetChangeStatus.columnMissing:
         return MaterialBanner(
-          backgroundColor: Colors.red.shade100,
-          leading: const Icon(Icons.error_outline, color: Colors.red),
+          backgroundColor: BiocentralStyle.alCriticalBackgroundColor,
+          leading: const Icon(Icons.error_outline, color: BiocentralStyle.alCriticalColor),
           content: Text(
             'The target column "${state.selectedCampaign?.columnName}" no longer exists in the loaded dataset. '
             'Further iterations are disabled. Export the campaign and fix your dataset before continuing!',

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -3,6 +3,7 @@ import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_database_grid_view.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_plot_view.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart';
+import 'package:biocentral/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart';
 import 'package:biocentral/sdk/biocentral_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -188,6 +189,10 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
                 campaign: campaign,
                 allResults: allResults,
               ),
+            ),
+            SizedBox(
+              width: widgetWidth,
+              child: ALPredictionErrorTrendView(campaign: campaign),
             ),
           ],
         );

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -25,6 +25,8 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
   void initState() {
     super.initState();
     _subTabController = TabController(length: 2, vsync: this);
+    final length = context.read<ALHubBloc>().state.selectedCampaign?.iterationResults.length ?? 0;
+    _selectedResultIndex = length > 0 ? length - 1 : 0;
   }
 
   @override
@@ -37,10 +39,13 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
   Widget build(BuildContext context) {
     super.build(context);
     return BlocConsumer<ALHubBloc, ALHubState>(
-      listenWhen: (previous, current) => previous.selectedCampaign?.internalName() != current.selectedCampaign?.internalName(),
+      listenWhen: (previous, current) =>
+          previous.selectedCampaign?.internalName() != current.selectedCampaign?.internalName() ||
+          previous.selectedCampaignIterationCount != current.selectedCampaignIterationCount,
       listener: (context, state) {
+        final length = state.selectedCampaign?.iterationResults.length ?? 0;
         setState(() {
-          _selectedResultIndex = 0;
+          _selectedResultIndex = length > 0 ? length - 1 : 0;
         });
       },
       builder: (context, hubState) {

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -18,6 +18,19 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
     with AutomaticKeepAliveClientMixin, TickerProviderStateMixin {
 
   int _selectedResultIndex = 0;
+  late TabController _subTabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _subTabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _subTabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,9 +44,7 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
       },
       builder: (context, hubState) {
         return Scaffold(
-          body: SingleChildScrollView(
-            child: buildContent(hubState),
-          ),
+          body: buildContent(hubState),
         );
       },
     );
@@ -44,7 +55,6 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
       return const Center(child: Text('No active learning campaigns yet!'));
     }
     return Column(
-      mainAxisSize: MainAxisSize.min,
       children: [
         Padding(
           padding: const EdgeInsets.all(16.0),
@@ -57,12 +67,31 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
                 context.read<ALHubBloc>().add(ALHubSelectCampaignEvent(campaign)),
           ),
         ),
-        if (hubState.selectedCampaign != null) buildResult(hubState.selectedCampaign!),
+        if (hubState.selectedCampaign != null) ...[
+          TabBar(
+            controller: _subTabController,
+            labelColor: Theme.of(context).colorScheme.onSurface,
+            unselectedLabelColor: Theme.of(context).colorScheme.onSurfaceVariant,
+            tabs: const [
+              Tab(icon: Icon(Icons.timeline), text: 'Current Iteration'),
+              Tab(icon: Icon(Icons.assessment), text: 'All Iterations'),
+            ],
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: _subTabController,
+              children: [
+                SingleChildScrollView(child: buildIterationView(hubState.selectedCampaign!)),
+                SingleChildScrollView(child: buildCampaignOverview(hubState.selectedCampaign!)),
+              ],
+            ),
+          ),
+        ],
       ],
     );
   }
 
-  Widget buildResult(ALCampaign campaign) {
+  Widget buildIterationView(ALCampaign campaign) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final widgetWidth = constraints.maxWidth * 0.8; // 90% of available width
@@ -85,7 +114,7 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
                 Text('Results for iteration: ${_selectedResultIndex + 1}'),
                 IconButton(
                   icon: const Icon(Icons.arrow_right),
-                  onPressed: _selectedResultIndex < totalIterations - 1  ? () => setState(() => _selectedResultIndex++) : null,
+                  onPressed: _selectedResultIndex < totalIterations - 1 ? () => setState(() => _selectedResultIndex++) : null,
                 ),
               ],
             ),
@@ -116,6 +145,49 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: buildPredictionErrorDisplay(campaign),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget buildCampaignOverview(ALCampaign campaign) {
+    final allResults = campaign.iterationResults.map((r) => r.$2).toList();
+    if (allResults.isEmpty) {
+      return const Center(child: Text('No iteration results available.'));
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final widgetWidth = constraints.maxWidth * 0.8; // 90% of available width
+        final widgetHeight = widgetWidth * 0.4; // Maintain aspect ratio
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(campaign.config.name),
+            SizedBox(
+              width: widgetWidth,
+              height: widgetHeight,
+              child: ALPlotView(
+                yLabel: 'Score',
+                allData: allResults,
+              ),
+            ),
+            SizedBox(
+              width: widgetWidth,
+              height: widgetHeight,
+              child: ALDatabaseGridView(
+                campaign: campaign,
+                displayedResult: null,
+              ),
+            ),
+            SizedBox(
+              width: widgetWidth,
+              child: ALPredictionComparisonView(
+                yLabel: campaign.columnName,
+                campaign: campaign,
+                allResults: allResults,
+              ),
             ),
           ],
         );

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -2,6 +2,7 @@ import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_database_grid_view.dart';
 import 'package:biocentral/plugins/active_learning/presentation/views/al_plot_view.dart';
+import 'package:biocentral/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart';
 import 'package:biocentral/sdk/biocentral_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -104,6 +105,14 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
                 displayedResult: campaign.iterationResults[_selectedResultIndex].$2,
               ),
             ),
+            SizedBox(
+              width: widgetWidth,
+              child: ALPredictionComparisonView(
+                yLabel: campaign.columnName,
+                campaign: campaign,
+                result: campaign.iterationResults[_selectedResultIndex].$2,
+              ),
+            ),
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: buildPredictionErrorDisplay(campaign),
@@ -115,7 +124,7 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
   }
 
   Widget buildPredictionErrorDisplay(ALCampaign campaign) {
-    final predictionError = null; // TODO
+    final double? predictionError = null; // TODO
     if (predictionError == null) {
       return Container();
     }

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -109,7 +109,7 @@ class ALPlotView extends StatelessWidget {
           result.score.toDouble(),
           show: true,
           dotPainter: FlDotCirclePainter(radius: 8, color: color),
-        ));
+        ),);
       }
     }
 
@@ -196,6 +196,7 @@ class ALPlotView extends StatelessWidget {
   ScatterTouchData _buildCombinedTouchData(List<(int, String, double)> spotInfo) {
     return ScatterTouchData(
       touchTooltipData: ScatterTouchTooltipData(
+        getTooltipColor: (_) => Colors.blueGrey.shade700,
         getTooltipItems: (ScatterSpot touchedSpot) {
           final index = touchedSpot.x.toInt() - 1;
           if (index < 0 || index >= spotInfo.length) return null;
@@ -363,6 +364,7 @@ class ALPlotView extends StatelessWidget {
   ScatterTouchData _buildTouchData() {
     return ScatterTouchData(
       touchTooltipData: ScatterTouchTooltipData(
+        getTooltipColor: (_) => Colors.blueGrey.shade700,
         getTooltipItems: (ScatterSpot touchedSpot) {
           return ScatterTooltipItem(
             '${_suggestedResults[touchedSpot.x.toInt() - 1].entityId}\n '

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -1,3 +1,4 @@
+import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -8,16 +9,6 @@ import 'package:flutter/material.dart';
 /// Points are color-coded based on their score values, with a gradient legend showing the score range.
 /// Supports single-iteration and combined multi-iteration modes.
 class ALPlotView extends StatelessWidget {
-  static const List<Color> _iterationColors = [
-    Colors.blue,
-    Colors.orange,
-    Colors.green,
-    Colors.purple,
-    Colors.red,
-    Colors.teal,
-    Colors.brown,
-    Colors.pink,
-  ];
   final String yLabel;
 
   /// The training results data to be displayed
@@ -101,7 +92,7 @@ class ALPlotView extends StatelessWidget {
 
     double counterX = 1.0;
     for (final (iteration, results) in _iterationData) {
-      final color = _iterationColors[iteration % _iterationColors.length];
+      final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
       for (final result in results) {
         spotInfo.add((iteration, result.entityId, result.score.toDouble()));
         spots.add(ScatterSpot(
@@ -196,14 +187,14 @@ class ALPlotView extends StatelessWidget {
   ScatterTouchData _buildCombinedTouchData(List<(int, String, double)> spotInfo) {
     return ScatterTouchData(
       touchTooltipData: ScatterTouchTooltipData(
-        getTooltipColor: (_) => Colors.blueGrey.shade700,
+        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
         getTooltipItems: (ScatterSpot touchedSpot) {
           final index = touchedSpot.x.toInt() - 1;
           if (index < 0 || index >= spotInfo.length) return null;
           final (iteration, entityId, score) = spotInfo[index];
           return ScatterTooltipItem(
             'Iteration $iteration\n$entityId\nScore: ${score.toStringAsFixed(Constants.maxDoublePrecision)}',
-            textStyle: const TextStyle(color: Colors.white, fontSize: 10),
+            textStyle: const TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 10),
           );
         },
       ),
@@ -220,7 +211,7 @@ class ALPlotView extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: _iterationData.map((entry) {
           final (iteration, _) = entry;
-          final color = _iterationColors[iteration % _iterationColors.length];
+          final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Row(
@@ -273,13 +264,7 @@ class ALPlotView extends StatelessWidget {
             decoration: BoxDecoration(
               border: Border.all(),
               gradient: const LinearGradient(
-                colors: [
-                  Colors.blue, // Low score
-                  Colors.purple,
-                  Colors.red,
-                  Colors.orange,
-                  Colors.yellow, // High score
-                ],
+                colors: BiocentralStyle.alScoreGradientColors,
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),
@@ -364,12 +349,12 @@ class ALPlotView extends StatelessWidget {
   ScatterTouchData _buildTouchData() {
     return ScatterTouchData(
       touchTooltipData: ScatterTouchTooltipData(
-        getTooltipColor: (_) => Colors.blueGrey.shade700,
+        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
         getTooltipItems: (ScatterSpot touchedSpot) {
           return ScatterTooltipItem(
             '${_suggestedResults[touchedSpot.x.toInt() - 1].entityId}\n '
             'Score: ${touchedSpot.y.toStringAsFixed(Constants.maxDoublePrecision)}',
-            textStyle: const TextStyle(color: Colors.white, fontSize: 10),
+            textStyle: const TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 10),
           );
         },
       ),
@@ -419,11 +404,11 @@ class ALPlotView extends StatelessWidget {
   /// Returns a color based on the score ratio (0.0 - 1.0)
   /// The color gradient goes from blue (low scores) to yellow (high scores)
   Color getColorBasedOnScore(double ratio) {
-    if (ratio <= 0.2) return Colors.blue;
-    if (ratio <= 0.4) return Colors.purple;
-    if (ratio <= 0.6) return Colors.red;
-    if (ratio <= 0.8) return Colors.orange;
-    return Colors.yellow;
+    if (ratio <= 0.2) return BiocentralStyle.alScoreGradientColors[0];
+    if (ratio <= 0.4) return BiocentralStyle.alScoreGradientColors[1];
+    if (ratio <= 0.6) return BiocentralStyle.alScoreGradientColors[2];
+    if (ratio <= 0.8) return BiocentralStyle.alScoreGradientColors[3];
+    return BiocentralStyle.alScoreGradientColors[4];
   }
 }
 

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -6,12 +6,26 @@ import 'package:flutter/material.dart';
 /// A widget that displays a scatter plot visualization of Active Learning results.
 /// The plot shows protein sequences on the x-axis and their corresponding scores on the y-axis.
 /// Points are color-coded based on their score values, with a gradient legend showing the score range.
+/// Supports single-iteration and combined multi-iteration modes.
 class ALPlotView extends StatelessWidget {
-  /// Label for the y-axis (typically representing the score metric)
+  static const List<Color> _iterationColors = [
+    Colors.blue,
+    Colors.orange,
+    Colors.green,
+    Colors.purple,
+    Colors.red,
+    Colors.teal,
+    Colors.brown,
+    Colors.pink,
+  ];
   final String yLabel;
 
   /// The training results data to be displayed
   final ActiveLearningIterationResult? data;
+  final List<ActiveLearningIterationResult>? allData;
+
+  final List<ActiveLearningResult> _suggestedResults;
+  final List<(int iteration, List<ActiveLearningResult> results)> _iterationData;
 
   /// Cached min/max values for the y-axis range
   final MinMaxValues minMaxValues;
@@ -19,11 +33,12 @@ class ALPlotView extends StatelessWidget {
   ALPlotView({
     required this.yLabel,
     this.data,
+    this.allData,
     super.key,
-  }) : _suggestedResults = _buildSuggestedResults(data),
-       minMaxValues = _calculateMinMax(_buildSuggestedResults(data));
-
-  final List<ActiveLearningResult> _suggestedResults;
+  }) : assert(data != null || allData != null, 'Either data or allData must be provided'),
+        _suggestedResults = allData == null ? _buildSuggestedResults(data) : const [],
+        _iterationData = allData != null ? _groupByIteration(allData) : const [],
+        minMaxValues = allData != null ? _calculateMinMax(_groupByIteration(allData).expand((e) => e.$2).toList(),) : _calculateMinMax(_buildSuggestedResults(data));
 
   static List<ActiveLearningResult> _buildSuggestedResults(ActiveLearningIterationResult? data) {
     if (data == null) return [];
@@ -31,10 +46,15 @@ class ALPlotView extends StatelessWidget {
     return data.results.where((r) => suggestionSet.contains(r.entityId)).toList();
   }
 
-  /// Gets the x-axis label from the training config
-  String get xLabel {
-    return 'Result plot for iteration: ${data?.iteration}';
+  static List<(int, List<ActiveLearningResult>)> _groupByIteration(List<ActiveLearningIterationResult> allData) {
+    return allData.map((r) {
+      final s = r.suggestions.toSet();
+      return (r.iteration, r.results.where((res) => s.contains(res.entityId)).toList());
+    }).toList();
   }
+
+  /// Gets the x-axis label from the training config
+  String get xLabel => 'Result plot for iteration: ${data?.iteration}';
 
   /// Calculates the minimum and maximum values for the y-axis
   /// Adds a 10% padding to both ends of the range
@@ -56,6 +76,9 @@ class ALPlotView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (allData != null) {
+      return _buildCombined();
+    }
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -69,7 +92,153 @@ class ALPlotView extends StatelessWidget {
     );
   }
 
-  /// Builds the main scatter plot visualization
+  Widget _buildCombined() {
+    final allResults = _iterationData.expand((e) => e.$2).toList();
+    if (allResults.isEmpty) return const SizedBox.shrink();
+
+    final List<(int iteration, String entityId, double score)> spotInfo = [];
+    final List<ScatterSpot> spots = [];
+
+    double counterX = 1.0;
+    for (final (iteration, results) in _iterationData) {
+      final color = _iterationColors[iteration % _iterationColors.length];
+      for (final result in results) {
+        spotInfo.add((iteration, result.entityId, result.score.toDouble()));
+        spots.add(ScatterSpot(
+          counterX++,
+          result.score.toDouble(),
+          show: true,
+          dotPainter: FlDotCirclePainter(radius: 8, color: color),
+        ));
+      }
+    }
+
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            Expanded(child: _buildCombinedScatterPlot(spots, spotInfo)),
+            _buildIterationLegend(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCombinedScatterPlot(
+    List<ScatterSpot> spots,
+    List<(int, String, double)> spotInfo,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: ScatterChart(
+        ScatterChartData(
+          titlesData: _buildCombinedTitlesData(spotInfo),
+          gridData: const FlGridData(),
+          scatterSpots: spots,
+          minX: 0,
+          maxX: spots.length.toDouble() + 1,
+          minY: minMaxValues.getMinY,
+          maxY: minMaxValues.getMaxY,
+          borderData: FlBorderData(show: true),
+          scatterTouchData: _buildCombinedTouchData(spotInfo),
+        ),
+      ),
+    );
+  }
+
+  FlTitlesData _buildCombinedTitlesData(List<(int, String, double)> spotInfo) {
+    return FlTitlesData(
+      rightTitles: const AxisTitles(),
+      topTitles: const AxisTitles(
+        axisNameWidget: Text(
+          'All Iterations',
+          style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+        ),
+      ),
+      leftTitles: AxisTitles(
+        axisNameWidget: Align(
+          alignment: Alignment.bottomCenter,
+          child: Text(yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+        ),
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 50,
+          getTitlesWidget: (value, meta) => Text(
+            value.toStringAsFixed(Constants.maxDoublePrecision),
+            style: const TextStyle(fontSize: 12),
+          ),
+        ),
+      ),
+      bottomTitles: AxisTitles(
+        sideTitles: SideTitles(
+          showTitles: true,
+          interval: 1,
+          reservedSize: 50,
+          getTitlesWidget: (value, meta) {
+            final int index = value.toInt();
+            if (index < 1 || index > spotInfo.length) return const SizedBox.shrink();
+            return RotatedBox(
+              quarterTurns: 3,
+              child: Text(
+                spotInfo[index - 1].$2,
+                style: const TextStyle(fontSize: 12),
+                textAlign: TextAlign.center,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  ScatterTouchData _buildCombinedTouchData(List<(int, String, double)> spotInfo) {
+    return ScatterTouchData(
+      touchTooltipData: ScatterTouchTooltipData(
+        getTooltipItems: (ScatterSpot touchedSpot) {
+          final index = touchedSpot.x.toInt() - 1;
+          if (index < 0 || index >= spotInfo.length) return null;
+          final (iteration, entityId, score) = spotInfo[index];
+          return ScatterTooltipItem(
+            'Iteration $iteration\n$entityId\nScore: ${score.toStringAsFixed(Constants.maxDoublePrecision)}',
+            textStyle: const TextStyle(color: Colors.white, fontSize: 10),
+          );
+        },
+      ),
+      enabled: true,
+    );
+  }
+
+  Widget _buildIterationLegend() {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      width: 120,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: _iterationData.map((entry) {
+          final (iteration, _) = entry;
+          final color = _iterationColors[iteration % _iterationColors.length];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              children: [
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+                ),
+                const SizedBox(width: 8),
+                Text('Iteration $iteration', style: const TextStyle(fontSize: 12)),
+              ],
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
   Widget _buildScatterPlot() {
     return Expanded(
       child: Padding(

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -1,6 +1,7 @@
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -75,11 +76,11 @@ class ALPredictionComparisonView extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  _legendDot(Colors.blue),
+                  _legendDot(BiocentralStyle.alPredictionLineColor),
                   const SizedBox(width: 4),
                   const Text('Prediction', style: TextStyle(fontSize: 12)),
                   const SizedBox(width: 16),
-                  _legendDot(Colors.orange),
+                  _legendDot(BiocentralStyle.alExperimentalLineColor),
                   const SizedBox(width: 4),
                   const Text('Experiment', style: TextStyle(fontSize: 12)),
                 ],
@@ -114,18 +115,18 @@ class ALPredictionComparisonView extends StatelessWidget {
     final predictionSeries = LineChartBarData(
       spots: data.asMap().entries.map((e) => FlSpot(e.key + 1.0, e.value.$2)).toList(),
       barWidth: 0,
-      color: Colors.blue,
+      color: BiocentralStyle.alPredictionLineColor,
       dotData: FlDotData(
-        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: Colors.blue),
+        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: BiocentralStyle.alPredictionLineColor),
       ),
     );
 
     final experimentalSeries = LineChartBarData(
       spots: data.asMap().entries.map((e) => FlSpot(e.key + 1.0, e.value.$3)).toList(),
       barWidth: 0,
-      color: Colors.orange,
+      color: BiocentralStyle.alExperimentalLineColor,
       dotData: FlDotData(
-        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: Colors.orange),
+        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: BiocentralStyle.alExperimentalLineColor),
       ),
     );
 
@@ -202,7 +203,7 @@ class ALPredictionComparisonView extends StatelessWidget {
       getTouchedSpotIndicator: (barData, spotIndexes) {
         if (barData == predictionSeries || barData == experimentalSeries) {
           return spotIndexes.map((_) => const TouchedSpotIndicatorData(
-            FlLine(color: Colors.transparent),
+            FlLine(color: BiocentralStyle.alConnectorLineColor),
             FlDotData(show: false),
           ),).toList();
         }
@@ -210,7 +211,7 @@ class ALPredictionComparisonView extends StatelessWidget {
         return spotIndexes.map((_) => null).toList();
       },
       touchTooltipData: LineTouchTooltipData(
-        getTooltipColor: (_) => Colors.blueGrey.shade700,
+        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
         getTooltipItems: (spots) {
           return spots.map((spot) {
             // connectors occupy barIndex 0..data.length-1; prediction is at data.length
@@ -225,7 +226,7 @@ class ALPredictionComparisonView extends StatelessWidget {
               'Prediction: ${prediction.toStringAsFixed(Constants.maxDoublePrecision)}\n'
               'Experiment: ${experimental.toStringAsFixed(Constants.maxDoublePrecision)}\n'
               'Δ: $sign${delta.toStringAsFixed(Constants.maxDoublePrecision)}',
-              const TextStyle(color: Colors.white, fontSize: 10),
+              const TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 10),
             );
           }).toList();
         },

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -1,14 +1,13 @@
-import 'dart:async';
 import 'package:bio_flutter/bio_flutter.dart';
+import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
-import 'package:biocentral/plugins/proteins/domain/protein_repository.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class ALPredictionComparisonView extends StatefulWidget {
+class ALPredictionComparisonView extends StatelessWidget {
   final String yLabel;
   final ALCampaign campaign;
   final ActiveLearningIterationResult? result;
@@ -22,35 +21,11 @@ class ALPredictionComparisonView extends StatefulWidget {
     super.key,
   }) : assert(result != null || allResults != null, 'Either result or allResults must be provided');
 
-  @override
-  State<ALPredictionComparisonView> createState() => _ALPredictionComparisonViewState();
-}
-
-class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView> {
-  StreamSubscription? _proteinSubscription;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _proteinSubscription ??= context.read<ProteinRepository>().databaseStream.listen((_) {
-      if (mounted) setState(() {});
-    });
-  }
-
-  @override
-  void dispose() {
-    _proteinSubscription?.cancel();
-    super.dispose();
-  }
-
-  /// Returns suggestions that have both a numeric prediction and an experimental value.
-  List<(ActiveLearningResult, double, double)> _plottableData() {
-    final proteinDb = context.read<ProteinRepository>().databaseToMap();
-
-    if (widget.allResults != null) {
-      return _plottableDataFromAll(proteinDb, widget.allResults!);
+  List<(ActiveLearningResult, double, double)> _plottableData(Map<String, Protein> proteinDb) {
+    if (allResults != null) {
+      return _plottableDataFromAll(proteinDb, allResults!);
     }
-    return _plottableDataFromSingle(proteinDb, widget.result!);
+    return _plottableDataFromSingle(proteinDb, result!);
   }
 
   List<(ActiveLearningResult, double, double)> _plottableDataFromSingle(Map<String, Protein> proteinDb, ActiveLearningIterationResult result) {
@@ -60,7 +35,7 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
       if (!suggestionSet.contains(r.entityId)) continue;
       final prediction = double.tryParse(r.prediction);
       if (prediction == null) continue;
-      final rawExperimental = proteinDb[r.entityId]?.attributes[widget.campaign.columnName];
+      final rawExperimental = proteinDb[r.entityId]?.attributes[campaign.columnName];
       final experimental = double.tryParse(rawExperimental?.toString() ?? '');
       if (experimental == null) continue;
       entries.add((r, prediction, experimental));
@@ -78,36 +53,41 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
 
   @override
   Widget build(BuildContext context) {
-    final data = _plottableData();
-    if (data.isEmpty) return const SizedBox.shrink();
-
-    return ExpansionTile(
-      title: const Text('Predictions vs. Experiments'),
-      leading: const Icon(Icons.compare_arrows),
-      children: [
-        SizedBox(
-          height: 500,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 35, 16, 24),
-            child: LineChart(_buildChartData(data)),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              _legendDot(Colors.blue),
-              const SizedBox(width: 4),
-              const Text('Prediction', style: TextStyle(fontSize: 12)),
-              const SizedBox(width: 16),
-              _legendDot(Colors.orange),
-              const SizedBox(width: 4),
-              const Text('Experiment', style: TextStyle(fontSize: 12)),
-            ],
-          ),
-        ),
-      ],
+    return BlocBuilder<ALHubBloc, ALHubState>(
+      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase || previous.selectedCampaign != current.selectedCampaign,
+      builder: (context, state) {
+        final data = _plottableData(state.proteinDatabase);
+        if (data.isEmpty) return const SizedBox.shrink();
+        
+        return ExpansionTile(
+          title: const Text('Predictions vs. Experiments'),
+          leading: const Icon(Icons.compare_arrows),
+          children: [
+            SizedBox(
+              height: 500,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 35, 16, 24),
+                child: LineChart(_buildChartData(data)),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _legendDot(Colors.blue),
+                  const SizedBox(width: 4),
+                  const Text('Prediction', style: TextStyle(fontSize: 12)),
+                  const SizedBox(width: 16),
+                  _legendDot(Colors.orange),
+                  const SizedBox(width: 4),
+                  const Text('Experiment', style: TextStyle(fontSize: 12)),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 
@@ -180,7 +160,7 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
       leftTitles: AxisTitles(
         axisNameWidget: Align(
           alignment: Alignment.bottomCenter,
-          child: Text(widget.yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+          child: Text(yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
         ),
         sideTitles: SideTitles(
           showTitles: true,
@@ -230,6 +210,7 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
         return spotIndexes.map((_) => null).toList();
       },
       touchTooltipData: LineTouchTooltipData(
+        getTooltipColor: (_) => Colors.blueGrey.shade700,
         getTooltipItems: (spots) {
           return spots.map((spot) {
             // connectors occupy barIndex 0..data.length-1; prediction is at data.length

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/plugins/proteins/domain/protein_repository.dart';
 import 'package:biocentral/sdk/util/constants.dart';
@@ -10,14 +11,16 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 class ALPredictionComparisonView extends StatefulWidget {
   final String yLabel;
   final ALCampaign campaign;
-  final ActiveLearningIterationResult result;
+  final ActiveLearningIterationResult? result;
+  final List<ActiveLearningIterationResult>? allResults;
 
   const ALPredictionComparisonView({
     required this.yLabel,
     required this.campaign,
-    required this.result,
+    this.result,
+    this.allResults,
     super.key,
-  });
+  }) : assert(result != null || allResults != null, 'Either result or allResults must be provided');
 
   @override
   State<ALPredictionComparisonView> createState() => _ALPredictionComparisonViewState();
@@ -43,9 +46,17 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
   /// Returns suggestions that have both a numeric prediction and an experimental value.
   List<(ActiveLearningResult, double, double)> _plottableData() {
     final proteinDb = context.read<ProteinRepository>().databaseToMap();
-    final suggestionSet = widget.result.suggestions.toSet();
+
+    if (widget.allResults != null) {
+      return _plottableDataFromAll(proteinDb, widget.allResults!);
+    }
+    return _plottableDataFromSingle(proteinDb, widget.result!);
+  }
+
+  List<(ActiveLearningResult, double, double)> _plottableDataFromSingle(Map<String, Protein> proteinDb, ActiveLearningIterationResult result) {
+    final suggestionSet = result.suggestions.toSet();
     final entries = <(ActiveLearningResult, double, double)>[];
-    for (final r in widget.result.results) {
+    for (final r in result.results) {
       if (!suggestionSet.contains(r.entityId)) continue;
       final prediction = double.tryParse(r.prediction);
       if (prediction == null) continue;
@@ -53,6 +64,14 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
       final experimental = double.tryParse(rawExperimental?.toString() ?? '');
       if (experimental == null) continue;
       entries.add((r, prediction, experimental));
+    }
+    return entries;
+  }
+
+  List<(ActiveLearningResult, double, double)> _plottableDataFromAll(Map<String, Protein> proteinDb, List<ActiveLearningIterationResult> allResults) {
+    final entries = <(ActiveLearningResult, double, double)>[];
+    for (final iterResult in allResults) {
+      entries.addAll(_plottableDataFromSingle(proteinDb, iterResult));
     }
     return entries;
   }
@@ -92,15 +111,11 @@ class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView>
     );
   }
 
-  Widget _legendDot(Color color, {bool stroke = false}) {
+  Widget _legendDot(Color color) {
     return Container(
       width: 12,
       height: 12,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: stroke ? Colors.white : color,
-        border: Border.all(color: color, width: stroke ? 2 : 0),
-      ),
+      decoration: BoxDecoration(shape: BoxShape.circle, color: color),
     );
   }
 

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/plugins/proteins/domain/protein_repository.dart';
+import 'package:biocentral/sdk/util/constants.dart';
+import 'package:biocentral_api/biocentral_api.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ALPredictionComparisonView extends StatefulWidget {
+  final String yLabel;
+  final ALCampaign campaign;
+  final ActiveLearningIterationResult result;
+
+  const ALPredictionComparisonView({
+    required this.yLabel,
+    required this.campaign,
+    required this.result,
+    super.key,
+  });
+
+  @override
+  State<ALPredictionComparisonView> createState() => _ALPredictionComparisonViewState();
+}
+
+class _ALPredictionComparisonViewState extends State<ALPredictionComparisonView> {
+  StreamSubscription? _proteinSubscription;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _proteinSubscription ??= context.read<ProteinRepository>().databaseStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _proteinSubscription?.cancel();
+    super.dispose();
+  }
+
+  /// Returns suggestions that have both a numeric prediction and an experimental value.
+  List<(ActiveLearningResult, double, double)> _plottableData() {
+    final proteinDb = context.read<ProteinRepository>().databaseToMap();
+    final suggestionSet = widget.result.suggestions.toSet();
+    final entries = <(ActiveLearningResult, double, double)>[];
+    for (final r in widget.result.results) {
+      if (!suggestionSet.contains(r.entityId)) continue;
+      final prediction = double.tryParse(r.prediction);
+      if (prediction == null) continue;
+      final rawExperimental = proteinDb[r.entityId]?.attributes[widget.campaign.columnName];
+      final experimental = double.tryParse(rawExperimental?.toString() ?? '');
+      if (experimental == null) continue;
+      entries.add((r, prediction, experimental));
+    }
+    return entries;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final data = _plottableData();
+    if (data.isEmpty) return const SizedBox.shrink();
+
+    return ExpansionTile(
+      title: const Text('Predictions vs. Experiments'),
+      leading: const Icon(Icons.compare_arrows),
+      children: [
+        SizedBox(
+          height: 500,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 35, 16, 24),
+            child: LineChart(_buildChartData(data)),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _legendDot(Colors.blue),
+              const SizedBox(width: 4),
+              const Text('Prediction', style: TextStyle(fontSize: 12)),
+              const SizedBox(width: 16),
+              _legendDot(Colors.orange),
+              const SizedBox(width: 4),
+              const Text('Experiment', style: TextStyle(fontSize: 12)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _legendDot(Color color, {bool stroke = false}) {
+    return Container(
+      width: 12,
+      height: 12,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: stroke ? Colors.white : color,
+        border: Border.all(color: color, width: stroke ? 2 : 0),
+      ),
+    );
+  }
+
+  LineChartData _buildChartData(List<(ActiveLearningResult, double, double)> data) {
+    double minY = double.infinity;
+    double maxY = double.negativeInfinity;
+    for (final (_, pred, exp) in data) {
+      if (pred < minY) minY = pred;
+      if (pred > maxY) maxY = pred;
+      if (exp < minY) minY = exp;
+      if (exp > maxY) maxY = exp;
+    }
+    final range = maxY - minY;
+    final padding = range == 0 ? 1.0 : range * 0.15;
+
+    final predictionSeries = LineChartBarData(
+      spots: data.asMap().entries.map((e) => FlSpot(e.key + 1.0, e.value.$2)).toList(),
+      barWidth: 0,
+      color: Colors.blue,
+      dotData: FlDotData(
+        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: Colors.blue),
+      ),
+    );
+
+    final experimentalSeries = LineChartBarData(
+      spots: data.asMap().entries.map((e) => FlSpot(e.key + 1.0, e.value.$3)).toList(),
+      barWidth: 0,
+      color: Colors.orange,
+      dotData: FlDotData(
+        getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(radius: 7, color: Colors.orange),
+      ),
+    );
+
+    final connectors = data.asMap().entries.map((e) {
+      final (_, pred, exp) = e.value;
+      return LineChartBarData(
+        spots: [FlSpot(e.key + 1.0, pred), FlSpot(e.key + 1.0, exp)],
+        barWidth: 1.5,
+        color: const Color.fromRGBO(120, 120, 120, 0.55),
+        dotData: const FlDotData(show: false),
+      );
+    }).toList();
+
+    final allSeries = [...connectors, predictionSeries, experimentalSeries];
+
+    return LineChartData(
+      minX: 0,
+      maxX: data.length + 1.0,
+      minY: minY - padding,
+      maxY: maxY + padding,
+      lineBarsData: allSeries,
+      titlesData: _buildTitlesData(data),
+      borderData: FlBorderData(show: true),
+      lineTouchData: _buildTouchData(data, predictionSeries, experimentalSeries),
+    );
+  }
+
+  FlTitlesData _buildTitlesData(List<(ActiveLearningResult, double, double)> data) {
+    return FlTitlesData(
+      rightTitles: const AxisTitles(),
+      topTitles: const AxisTitles(sideTitles: SideTitles(reservedSize: 40)),
+      leftTitles: AxisTitles(
+        axisNameWidget: Align(
+          alignment: Alignment.bottomCenter,
+          child: Text(widget.yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+        ),
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 50,
+          getTitlesWidget: (value, meta) => Text(
+            value.toStringAsFixed(Constants.maxDoublePrecision),
+            style: const TextStyle(fontSize: 11),
+          ),
+        ),
+      ),
+      bottomTitles: AxisTitles(
+        sideTitles: SideTitles(
+          showTitles: true,
+          interval: 1,
+          reservedSize: 80,
+          getTitlesWidget: (value, meta) {
+            final index = value.toInt();
+            if (index < 1 || index > data.length) return const SizedBox.shrink();
+            return RotatedBox(
+              quarterTurns: 3,
+              child: Text(
+                data[index - 1].$1.entityId,
+                style: const TextStyle(fontSize: 11),
+                textAlign: TextAlign.center,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  LineTouchData _buildTouchData(
+    List<(ActiveLearningResult, double, double)> data,
+    LineChartBarData predictionSeries,
+    LineChartBarData experimentalSeries,
+  ) {
+    return LineTouchData(
+      getTouchedSpotIndicator: (barData, spotIndexes) {
+        if (barData == predictionSeries || barData == experimentalSeries) {
+          return spotIndexes.map((_) => const TouchedSpotIndicatorData(
+            FlLine(color: Colors.transparent),
+            FlDotData(show: false),
+          ),).toList();
+        }
+        // Hide indicators on connector segments
+        return spotIndexes.map((_) => null).toList();
+      },
+      touchTooltipData: LineTouchTooltipData(
+        getTooltipItems: (spots) {
+          return spots.map((spot) {
+            // connectors occupy barIndex 0..data.length-1; prediction is at data.length
+            if (spot.barIndex != data.length) return null;
+            final index = spot.x.toInt() - 1;
+            if (index < 0 || index >= data.length) return null;
+            final (result, prediction, experimental) = data[index];
+            final delta = experimental - prediction;
+            final sign = delta >= 0 ? '+' : '';
+            return LineTooltipItem(
+              '${result.entityId}\n'
+              'Prediction: ${prediction.toStringAsFixed(Constants.maxDoublePrecision)}\n'
+              'Experiment: ${experimental.toStringAsFixed(Constants.maxDoublePrecision)}\n'
+              'Δ: $sign${delta.toStringAsFixed(Constants.maxDoublePrecision)}',
+              const TextStyle(color: Colors.white, fontSize: 10),
+            );
+          }).toList();
+        },
+      ),
+    );
+  }
+}

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -69,7 +69,7 @@ class ALPredictionErrorTrendView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ALHubBloc, ALHubState>(
-      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase,
+      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase || previous.selectedCampaign != current.selectedCampaign,
       builder: (context, state) {
         final stats = _computeStats(state.proteinDatabase);
         if (stats.isEmpty) return const SizedBox.shrink();
@@ -84,35 +84,9 @@ class ALPredictionErrorTrendView extends StatelessWidget {
                 child: CandlestickChart(_buildChartData(stats)),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  _legendItem(_bodyColor, 'IQR (body)'),
-                  const SizedBox(width: 16),
-                  _legendItem(_bodyColor, 'Min – Max (wicks)'),
-                ],
-              ),
-            ),
           ],
         );
       },
-    );
-  }
-
-  Widget _legendItem(Color color, String label) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: 12,
-          height: 12,
-          decoration: BoxDecoration(shape: BoxShape.circle, color: color),
-        ),
-        const SizedBox(width: 4),
-        Text(label, style: const TextStyle(fontSize: 12)),
-      ],
     );
   }
 
@@ -142,6 +116,8 @@ class ALPredictionErrorTrendView extends StatelessWidget {
 
     return CandlestickChartData(
       candlestickSpots: spots,
+      minX: stats.first.iteration.toDouble() - 1.0,
+      maxX: stats.last.iteration.toDouble() + 1.0,
       candlestickPainter: DefaultCandlestickPainter(
         candlestickStyleProvider: (spot, _) => const CandlestickStyle(
           lineColor: _bodyColor,
@@ -212,7 +188,7 @@ class ALPredictionErrorTrendView extends StatelessWidget {
         fitInsideHorizontally: true,
         fitInsideVertically: true,
         maxContentWidth: 180,
-        getTooltipColor: (_) => Colors.blueGrey.shade800,
+        getTooltipColor: (_) => Colors.blueGrey.shade700,
         getTooltipItems: (painter, spot, spotIndex) {
           if (spotIndex < 0 || spotIndex >= stats.length) return null;
           final s = stats[spotIndex];

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -1,6 +1,7 @@
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -11,7 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// iteration. Each candle maps: low=min, open=Q1, close=Q3, high=max.
 /// Hides itself when no iteration has experimental data to compare.
 class ALPredictionErrorTrendView extends StatelessWidget {
-  static const Color _bodyColor = Color(0xFF673AB7); // deepPurple 500
+  static const Color _bodyColor = BiocentralStyle.alPredictionErrorBodyColor;
 
   final ALCampaign campaign;
 
@@ -188,12 +189,12 @@ class ALPredictionErrorTrendView extends StatelessWidget {
         fitInsideHorizontally: true,
         fitInsideVertically: true,
         maxContentWidth: 180,
-        getTooltipColor: (_) => Colors.blueGrey.shade700,
+        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
         getTooltipItems: (painter, spot, spotIndex) {
           if (spotIndex < 0 || spotIndex >= stats.length) return null;
           final s = stats[spotIndex];
           String fmt(double v) => v.toStringAsFixed(Constants.maxDoublePrecision);
-          const style = TextStyle(color: Colors.white, fontSize: 11);
+          const style = TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 11);
           return CandlestickTooltipItem(
             'Iteration ${s.iteration}\n',
             textStyle: style,

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -1,0 +1,163 @@
+import 'package:bio_flutter/bio_flutter.dart';
+import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
+import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/util/constants.dart';
+import 'package:biocentral_api/biocentral_api.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Line chart showing how the average absolute prediction error (MAE) evolves
+/// across iterations for the selected campaign.
+/// Returns [SizedBox.shrink] when no iteration has experimental data to compare.
+class ALPredictionErrorTrendView extends StatelessWidget {
+  static const Color _plotColor = Colors.pink;
+
+  final ALCampaign campaign;
+
+  const ALPredictionErrorTrendView({required this.campaign, super.key});
+
+  /// Computes per-iteration MAE using only suggested proteins that have
+  /// both a numeric prediction and an experimental value in [proteinDatabase].
+  List<(int iteration, double mae)> _computeErrorsPerIteration(Map<String, Protein> proteinDatabase) {
+    final points = <(int, double)>[];
+    for (final (_, iterResult) in campaign.iterationResults) {
+      final mae = _computeMAE(iterResult, proteinDatabase);
+      if (mae != null) {
+        points.add((iterResult.iteration, mae));
+      }
+    }
+    return points;
+  }
+
+  double? _computeMAE(ActiveLearningIterationResult iterResult, Map<String, Protein> proteinDatabase) {
+    final suggestionSet = iterResult.suggestions.toSet();
+    final errors = <double>[];
+    for (final result in iterResult.results) {
+      if (!suggestionSet.contains(result.entityId)) continue;
+      final prediction = double.tryParse(result.prediction);
+      if (prediction == null) continue;
+      final rawExp = proteinDatabase[result.entityId]?.attributes[campaign.columnName];
+      final experimental = double.tryParse(rawExp?.toString() ?? '');
+      if (experimental == null) continue;
+      errors.add((experimental - prediction).abs());
+    }
+    if (errors.isEmpty) return null;
+    return errors.reduce((a, b) => a + b) / errors.length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ALHubBloc, ALHubState>(
+      buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase,
+      builder: (context, state) {
+        final points = _computeErrorsPerIteration(state.proteinDatabase);
+        if (points.isEmpty) return const SizedBox.shrink();
+        return ExpansionTile(
+          title: const Text('Prediction Error Trend'),
+          leading: const Icon(Icons.show_chart),
+          children: [
+            SizedBox(
+              height: 300,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 24, 32, 16),
+                child: LineChart(_buildChartData(points)),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  LineChartData _buildChartData(List<(int, double)> points) {
+    double minY = double.infinity;
+    double maxY = double.negativeInfinity;
+    for (final (_, mae) in points) {
+      if (mae < minY) minY = mae;
+      if (mae > maxY) maxY = mae;
+    }
+    final range = maxY - minY;
+    final yPadding = range == 0 ? 1.0 : range * 0.2;
+
+    final spots = points.map((p) => FlSpot(p.$1.toDouble(), p.$2)).toList();
+
+    final series = LineChartBarData(
+      spots: spots,
+      isCurved: points.length > 2,
+      color: _plotColor,
+      dotData: FlDotData(
+        getDotPainter: (_, __, ___, ____) =>
+            FlDotCirclePainter(radius: 5, color: _plotColor),
+      ),
+      belowBarData: BarAreaData(
+        show: true,
+        color: _plotColor.withAlpha(30),
+      ),
+    );
+
+    return LineChartData(
+      minY: minY - yPadding,
+      maxY: maxY + yPadding,
+      lineBarsData: [series],
+      titlesData: _buildTitlesData(points),
+      borderData: FlBorderData(show: true),
+      lineTouchData: _buildTouchData(),
+    );
+  }
+
+  FlTitlesData _buildTitlesData(List<(int, double)> points) {
+    final iterationNumbers = points.map((p) => p.$1).toSet();
+    return FlTitlesData(
+      rightTitles: const AxisTitles(),
+      topTitles: const AxisTitles(),
+      leftTitles: AxisTitles(
+        axisNameWidget: const Align(
+          alignment: Alignment.bottomCenter,
+          child: Text(
+            'MAE',
+            style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+          ),
+        ),
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 56,
+          getTitlesWidget: (value, meta) => Text(
+            value.toStringAsFixed(Constants.maxDoublePrecision),
+            style: const TextStyle(fontSize: 11),
+          ),
+        ),
+      ),
+      bottomTitles: AxisTitles(
+        axisNameWidget: const Text(
+          'Iteration',
+          style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+        ),
+        sideTitles: SideTitles(
+          showTitles: true,
+          interval: 1,
+          reservedSize: 32,
+          getTitlesWidget: (value, meta) {
+            final iter = value.toInt();
+            if (!iterationNumbers.contains(iter)) return const SizedBox.shrink();
+            return Text('$iter', style: const TextStyle(fontSize: 11));
+          },
+        ),
+      ),
+    );
+  }
+
+  LineTouchData _buildTouchData() {
+    return LineTouchData(
+      touchTooltipData: LineTouchTooltipData(
+        getTooltipItems: (spots) => spots.map((spot) {
+          return LineTooltipItem(
+            'Iteration ${spot.x.toInt()}\n'
+            'MAE: ${spot.y.toStringAsFixed(Constants.maxDoublePrecision)}',
+            const TextStyle(color: Colors.white, fontSize: 10),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -7,30 +7,22 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-/// Line chart showing how the average absolute prediction error (MAE) evolves
-/// across iterations for the selected campaign.
-/// Returns [SizedBox.shrink] when no iteration has experimental data to compare.
+/// Candlestick chart showing the distribution of absolute prediction errors per
+/// iteration. Each candle maps: low=min, open=Q1, close=Q3, high=max.
+/// Hides itself when no iteration has experimental data to compare.
 class ALPredictionErrorTrendView extends StatelessWidget {
-  static const Color _plotColor = Colors.pink;
+  static const Color _bodyColor = Color(0xFF673AB7); // deepPurple 500
 
   final ALCampaign campaign;
 
   const ALPredictionErrorTrendView({required this.campaign, super.key});
 
-  /// Computes per-iteration MAE using only suggested proteins that have
-  /// both a numeric prediction and an experimental value in [proteinDatabase].
-  List<(int iteration, double mae)> _computeErrorsPerIteration(Map<String, Protein> proteinDatabase) {
-    final points = <(int, double)>[];
-    for (final (_, iterResult) in campaign.iterationResults) {
-      final mae = _computeMAE(iterResult, proteinDatabase);
-      if (mae != null) {
-        points.add((iterResult.iteration, mae));
-      }
-    }
-    return points;
-  }
-
-  double? _computeMAE(ActiveLearningIterationResult iterResult, Map<String, Protein> proteinDatabase) {
+  /// Returns sorted absolute errors for all suggested proteins in [iterResult]
+  /// that have both a numeric prediction and an experimental value.
+  List<double> _errorsForIteration(
+    ActiveLearningIterationResult iterResult,
+    Map<String, Protein> proteinDatabase,
+  ) {
     final suggestionSet = iterResult.suggestions.toSet();
     final errors = <double>[];
     for (final result in iterResult.results) {
@@ -42,8 +34,36 @@ class ALPredictionErrorTrendView extends StatelessWidget {
       if (experimental == null) continue;
       errors.add((experimental - prediction).abs());
     }
-    if (errors.isEmpty) return null;
-    return errors.reduce((a, b) => a + b) / errors.length;
+    errors.sort();
+    return errors;
+  }
+
+  double _quartile(List<double> sorted, double q) {
+    final pos = (sorted.length - 1) * q;
+    final lower = pos.floor();
+    final upper = pos.ceil();
+    if (lower == upper) return sorted[lower];
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * (pos - lower);
+  }
+
+  /// Builds one record per iteration: (iteration, min, q1, q3, max, mean).
+  List<({int iteration, double min, double q1, double q3, double max, double mean})>
+      _computeStats(Map<String, Protein> proteinDatabase) {
+    final result =
+        <({int iteration, double min, double q1, double q3, double max, double mean})>[];
+    for (final (_, iterResult) in campaign.iterationResults) {
+      final errors = _errorsForIteration(iterResult, proteinDatabase);
+      if (errors.isEmpty) continue;
+      result.add((
+        iteration: iterResult.iteration,
+        min: errors.first,
+        q1: _quartile(errors, 0.25),
+        q3: _quartile(errors, 0.75),
+        max: errors.last,
+        mean: errors.reduce((a, b) => a + b) / errors.length,
+      ),);
+    }
+    return result;
   }
 
   @override
@@ -51,17 +71,28 @@ class ALPredictionErrorTrendView extends StatelessWidget {
     return BlocBuilder<ALHubBloc, ALHubState>(
       buildWhen: (previous, current) => previous.proteinDatabase != current.proteinDatabase,
       builder: (context, state) {
-        final points = _computeErrorsPerIteration(state.proteinDatabase);
-        if (points.isEmpty) return const SizedBox.shrink();
+        final stats = _computeStats(state.proteinDatabase);
+        if (stats.isEmpty) return const SizedBox.shrink();
         return ExpansionTile(
-          title: const Text('Prediction Error Trend'),
-          leading: const Icon(Icons.show_chart),
+          title: const Text('Prediction Error Distribution'),
+          leading: const Icon(Icons.candlestick_chart),
           children: [
             SizedBox(
               height: 300,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(16, 24, 32, 16),
-                child: LineChart(_buildChartData(points)),
+                child: CandlestickChart(_buildChartData(stats)),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _legendItem(_bodyColor, 'IQR (body)'),
+                  const SizedBox(width: 16),
+                  _legendItem(_bodyColor, 'Min – Max (wicks)'),
+                ],
               ),
             ),
           ],
@@ -70,44 +101,70 @@ class ALPredictionErrorTrendView extends StatelessWidget {
     );
   }
 
-  LineChartData _buildChartData(List<(int, double)> points) {
+  Widget _legendItem(Color color, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+        ),
+        const SizedBox(width: 4),
+        Text(label, style: const TextStyle(fontSize: 12)),
+      ],
+    );
+  }
+
+  CandlestickChartData _buildChartData(
+    List<({int iteration, double min, double q1, double q3, double max, double mean})> stats,
+  ) {
     double minY = double.infinity;
     double maxY = double.negativeInfinity;
-    for (final (_, mae) in points) {
-      if (mae < minY) minY = mae;
-      if (mae > maxY) maxY = mae;
+    for (final s in stats) {
+      if (s.min < minY) minY = s.min;
+      if (s.max > maxY) maxY = s.max;
     }
     final range = maxY - minY;
     final yPadding = range == 0 ? 1.0 : range * 0.2;
 
-    final spots = points.map((p) => FlSpot(p.$1.toDouble(), p.$2)).toList();
+    final spots = stats
+        .map(
+          (s) => CandlestickSpot(
+            x: s.iteration.toDouble(),
+            open: s.q1,
+            high: s.max,
+            low: s.min,
+            close: s.q3,
+          ),
+        )
+        .toList();
 
-    final series = LineChartBarData(
-      spots: spots,
-      isCurved: points.length > 2,
-      color: _plotColor,
-      dotData: FlDotData(
-        getDotPainter: (_, __, ___, ____) =>
-            FlDotCirclePainter(radius: 5, color: _plotColor),
+    return CandlestickChartData(
+      candlestickSpots: spots,
+      candlestickPainter: DefaultCandlestickPainter(
+        candlestickStyleProvider: (spot, _) => const CandlestickStyle(
+          lineColor: _bodyColor,
+          lineWidth: 1.5,
+          bodyStrokeColor: _bodyColor,
+          bodyStrokeWidth: 0,
+          bodyFillColor: _bodyColor,
+          bodyWidth: 16,
+          bodyRadius: 2,
+        ),
       ),
-      belowBarData: BarAreaData(
-        show: true,
-        color: _plotColor.withAlpha(30),
-      ),
-    );
-
-    return LineChartData(
       minY: minY - yPadding,
       maxY: maxY + yPadding,
-      lineBarsData: [series],
-      titlesData: _buildTitlesData(points),
       borderData: FlBorderData(show: true),
-      lineTouchData: _buildTouchData(),
+      titlesData: _buildTitlesData(stats),
+      candlestickTouchData: _buildTouchData(stats),
     );
   }
 
-  FlTitlesData _buildTitlesData(List<(int, double)> points) {
-    final iterationNumbers = points.map((p) => p.$1).toSet();
+  FlTitlesData _buildTitlesData(
+    List<({int iteration, double min, double q1, double q3, double max, double mean})> stats,
+  ) {
+    final iterNums = stats.map((s) => s.iteration).toSet();
     return FlTitlesData(
       rightTitles: const AxisTitles(),
       topTitles: const AxisTitles(),
@@ -115,7 +172,7 @@ class ALPredictionErrorTrendView extends StatelessWidget {
         axisNameWidget: const Align(
           alignment: Alignment.bottomCenter,
           child: Text(
-            'MAE',
+            'Absolute Error',
             style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
           ),
         ),
@@ -139,7 +196,7 @@ class ALPredictionErrorTrendView extends StatelessWidget {
           reservedSize: 32,
           getTitlesWidget: (value, meta) {
             final iter = value.toInt();
-            if (!iterationNumbers.contains(iter)) return const SizedBox.shrink();
+            if (!iterNums.contains(iter)) return const SizedBox.shrink();
             return Text('$iter', style: const TextStyle(fontSize: 11));
           },
         ),
@@ -147,16 +204,32 @@ class ALPredictionErrorTrendView extends StatelessWidget {
     );
   }
 
-  LineTouchData _buildTouchData() {
-    return LineTouchData(
-      touchTooltipData: LineTouchTooltipData(
-        getTooltipItems: (spots) => spots.map((spot) {
-          return LineTooltipItem(
-            'Iteration ${spot.x.toInt()}\n'
-            'MAE: ${spot.y.toStringAsFixed(Constants.maxDoublePrecision)}',
-            const TextStyle(color: Colors.white, fontSize: 10),
+  CandlestickTouchData _buildTouchData(
+    List<({int iteration, double min, double q1, double q3, double max, double mean})> stats,
+  ) {
+    return CandlestickTouchData(
+      touchTooltipData: CandlestickTouchTooltipData(
+        fitInsideHorizontally: true,
+        fitInsideVertically: true,
+        maxContentWidth: 180,
+        getTooltipColor: (_) => Colors.blueGrey.shade800,
+        getTooltipItems: (painter, spot, spotIndex) {
+          if (spotIndex < 0 || spotIndex >= stats.length) return null;
+          final s = stats[spotIndex];
+          String fmt(double v) => v.toStringAsFixed(Constants.maxDoublePrecision);
+          const style = TextStyle(color: Colors.white, fontSize: 11);
+          return CandlestickTooltipItem(
+            'Iteration ${s.iteration}\n',
+            textStyle: style,
+            children: [
+              TextSpan(text: 'MAE: ${fmt(s.mean)}\n', style: style),
+              TextSpan(text: 'Min: ${fmt(s.min)}\n', style: style),
+              TextSpan(text: 'Q1:  ${fmt(s.q1)}\n', style: style),
+              TextSpan(text: 'Q3:  ${fmt(s.q3)}\n', style: style),
+              TextSpan(text: 'Max: ${fmt(s.max)}', style: style),
+            ],
           );
-        }).toList(),
+        },
       ),
     );
   }

--- a/lib/sdk/presentation/style/biocentral_style.dart
+++ b/lib/sdk/presentation/style/biocentral_style.dart
@@ -44,4 +44,36 @@ class BiocentralStyle {
       bodyMedium: TextStyle(fontSize: 18, fontWeight: FontWeight.normal, color: Colors.black),
     ),
   );
+
+  // Active Learning colors
+  static const Color alTooltipBackground = Color(0xFF455A64);
+  static const Color alTooltipTextColor = Colors.white;
+  static const Color alConnectorLineColor = Colors.transparent;
+  static const Color alPredictionErrorBodyColor = Color(0xFF673AB7);
+  static const Color alPredictionLineColor = Colors.blue;
+  static const Color alExperimentalLineColor = Colors.orange;
+  static const Color alWarningColor = Colors.orange;
+  static const Color alWarningBackgroundColor = Color(0xFFFFE0B2);
+  static const Color alWarningTextColor = Color(0xFFEF6C00);
+  static const Color alSuccessColor = Colors.green;
+  static const Color alSuccessTextColor = Color(0xFF388E3C);
+  static const Color alCriticalColor = Colors.red;
+  static const Color alCriticalBackgroundColor = Color(0xFFFFCDD2);
+  static const List<Color> alIterationColors = [
+    Colors.blue,
+    Colors.orange,
+    Colors.green,
+    Colors.purple,
+    Colors.red,
+    Colors.teal,
+    Colors.brown,
+    Colors.pink,
+  ];
+  static const List<Color> alScoreGradientColors = [
+    Colors.blue,
+    Colors.purple,
+    Colors.red,
+    Colors.orange,
+    Colors.yellow,
+  ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   archive: ^3.6.1
   async: ^2.11.0
   auto_size_text: ^3.0.0
-  bio_flutter: ^0.0.11
+  bio_flutter: ^0.0.12
   biocentral_api: ^1.2.0
   bloc: ^8.1.3
   bloc_effects: ^1.0.4
@@ -21,7 +21,7 @@ dependencies:
   equatable: ^2.0.5
   event_bus: ^2.0.0
   file_picker: ^8.0.3
-  fl_chart: ^0.69.2
+  fl_chart: ^1.2.0
   flutter:
     sdk: flutter
   flutter_animate: ^4.5.0


### PR DESCRIPTION
New features:

- Tabbed iteration result view
The results view is now split into two tabs. One shows data for a single selected iteration and one shows an aggregated overview across all iterations. Plots and the data table adjust automatically depending on which tab is active

- Prediction error trend chart
A new chart has been added showing how the distribution of absolute prediction errors evolves across iterations, displayed as a box plot (min, Q1, mean, Q3, max per iteration)

- Experimental data input redesign
The form for entering experimental results has been changed. Suggested proteins remain primary input. New secondary section allows addition of data for any other sequence in the loaded dataset, with staged entries shown in a list that can be edited before submitting

- Campaign export and import
Users can save individual campaigns to a JSON file and load them back at later point. When loading, a confirmation screen is shown listing which campaigns would be added and which would overwrite an existing campaign with the same name

- Dataset change detection
The plugin now detects when the loaded protein dataset has changed in a way that affects the active campaign. If some suggested proteins have gone missing a warning banner is shown. If the target column itself is missing, a more severe banner is shown and running further iterations is disabled until the dataset is fixed (user is also askedto save the current campaign)