### PR TITLE
remove duplicate text/information & change padding / layout

### DIFF
--- a/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/add_experimental_data_command_display.dart
@@ -106,7 +106,7 @@ class _AddExperimentalDataCommandDisplayState extends State<AddExperimentalDataC
 
   Widget buildParameterSelection(List<ALCampaign> campaigns, Map<String, Protein> proteinDatabase) {
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
           withCondition(condition: true, childFunction: buildDatasetSelection),

--- a/lib/plugins/active_learning/presentation/commands/al_export_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_export_campaign_command_display.dart
@@ -64,7 +64,7 @@ class _ALExportCampaignCommandDisplayState extends State<ALExportCampaignCommand
   Widget buildParameterSelection(List<ALCampaign> campaigns) {
     final defaultFileName = 'campaign_${_selectedCampaign?.config.name ?? 'export'}.json';
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
           BiocentralDiscreteSelection<ALCampaign>(

--- a/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_import_campaign_command_display.dart
@@ -93,7 +93,7 @@ class _ALImportCampaignCommandDisplayState extends State<ALImportCampaignCommand
 
   Widget buildParameterSelection() {
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
           BiocentralFilePathSelection(

--- a/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/al_iteration_command_display.dart
@@ -103,7 +103,7 @@ class _ALIterationCommandDisplayState extends State<ALIterationCommandDisplay> {
 
   Widget buildParameterSelection(List<ALCampaign> campaigns) {
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
           withCondition(condition: true, childFunction: buildDatasetSelection),
@@ -112,11 +112,7 @@ class _ALIterationCommandDisplayState extends State<ALIterationCommandDisplay> {
             childFunction: () => buildCampaignSelection(campaigns),
           ),
           withCondition(condition: _selectedCampaign != null, childFunction: buildIterationConfigSelection),
-        ].withPadding(
-          const Padding(
-            padding: EdgeInsetsGeometry.all(8.0),
-          ),
-        ),
+        ].withPadding(const Padding(padding: EdgeInsetsGeometry.all(8.0))),
       ),
     );
   }

--- a/lib/plugins/active_learning/presentation/commands/new_al_campaign_command_display.dart
+++ b/lib/plugins/active_learning/presentation/commands/new_al_campaign_command_display.dart
@@ -141,7 +141,7 @@ class _NewALCampaignCommandDisplayState extends State<NewALCampaignCommandDispla
 
   Widget buildParameterSelection() {
     return Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
           withCondition(condition: true, childFunction: buildCampaignNameInput),

--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -109,7 +109,6 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(campaign.config.name),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -170,7 +169,6 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(campaign.config.name),
             SizedBox(
               width: widgetWidth,
               height: widgetHeight,

--- a/lib/sdk/presentation/widgets/biocentral_command_view.dart
+++ b/lib/sdk/presentation/widgets/biocentral_command_view.dart
@@ -13,7 +13,12 @@ class _BiocentralCommandViewState extends State<BiocentralCommandView> with Auto
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return SingleChildScrollView(child: Column(children: widget.commandWidgets));
+    return SingleChildScrollView(
+        child: Column(
+          spacing: 2.0,
+          children: widget.commandWidgets,
+        ),
+    );
   }
 
   @override

--- a/lib/sdk/presentation/widgets/biocentral_command_view.dart
+++ b/lib/sdk/presentation/widgets/biocentral_command_view.dart
@@ -1,3 +1,4 @@
+import 'package:biocentral/sdk/presentation/widgets/biocentral_command_widget.dart';
 import 'package:flutter/material.dart';
 
 class BiocentralCommandView extends StatefulWidget {
@@ -10,14 +11,25 @@ class BiocentralCommandView extends StatefulWidget {
 }
 
 class _BiocentralCommandViewState extends State<BiocentralCommandView> with AutomaticKeepAliveClientMixin {
+  final _expandedToken = ValueNotifier<Object?>(null);
+
+  @override
+  void dispose() {
+    _expandedToken.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return SingleChildScrollView(
+    return BiocentralCommandGroupScope(
+      notifier: _expandedToken,
+      child: SingleChildScrollView(
         child: Column(
           spacing: 2.0,
           children: widget.commandWidgets,
         ),
+      ),
     );
   }
 

--- a/lib/sdk/presentation/widgets/biocentral_command_widget.dart
+++ b/lib/sdk/presentation/widgets/biocentral_command_widget.dart
@@ -132,7 +132,6 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
         const Divider(),
         const Text('Select Parameters:'),
         widget.parameterSelection(),
-        const SizedBox(height: 8.0),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -147,15 +146,15 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
                     },
             ),
             const Text('Automatically accept result'),
+            const SizedBox(width: 16),
+            ElevatedButton.icon(
+              onPressed: executeCommand,
+              icon: const Icon(Icons.play_circle_outline),
+              label: Text(widget.executeButtonLabel.toUpperCase()),
+            ),
           ],
         ),
-        ElevatedButton.icon(
-          onPressed: executeCommand,
-          icon: const Icon(Icons.play_circle_outline),
-          label: Text(widget.executeButtonLabel.toUpperCase()),
-        ),
-        const Divider(),
-      ].withPadding(const Padding(padding: EdgeInsets.all(8.0))),
+      ].withPadding(const Padding(padding: EdgeInsets.all(4.0))),
     );
   }
 }

--- a/lib/sdk/presentation/widgets/biocentral_command_widget.dart
+++ b/lib/sdk/presentation/widgets/biocentral_command_widget.dart
@@ -6,6 +6,14 @@ import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+class BiocentralCommandGroupScope extends InheritedNotifier<ValueNotifier<Object?>> {
+  const BiocentralCommandGroupScope({required super.notifier, required super.child, super.key});
+
+  static ValueNotifier<Object?>? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<BiocentralCommandGroupScope>()?.notifier;
+  }
+}
+
 class BiocentralCommandWidget extends StatefulWidget {
   final Icon icon;
   final String name;
@@ -54,8 +62,27 @@ class BiocentralCommandWidget extends StatefulWidget {
 }
 
 class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
+  final Object _token = Object();
   bool _selected = false;
   bool _autoAccept = false;
+
+  void _expand() {
+    final notifier = BiocentralCommandGroupScope.maybeOf(context);
+    if (notifier != null) {
+      notifier.value = _token;
+    } else {
+      setState(() => _selected = true);
+    }
+  }
+
+  void _collapse() {
+    final notifier = BiocentralCommandGroupScope.maybeOf(context);
+    if (notifier != null) {
+      if (notifier.value == _token) notifier.value = null;
+    } else {
+      setState(() => _selected = false);
+    }
+  }
 
   void executeCommand() {
     final BiocentralCommandBloc commandBloc = context.read<BiocentralCommandBloc>();
@@ -77,12 +104,11 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final notifier = BiocentralCommandGroupScope.maybeOf(context);
+    final isExpanded = notifier != null ? notifier.value == _token : _selected;
+
     final unselectedWidget = InkWell(
-      onTap: widget.commandAvailability.available
-          ? () => setState(() {
-                _selected = true;
-              })
-          : null,
+      onTap: widget.commandAvailability.available ? _expand : null,
       child: Card(
         color: widget.commandAvailability.available ? null : Colors.grey[300],
         child: Padding(
@@ -90,11 +116,7 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
           child: Row(
             children: [
               IconButton.filled(
-                onPressed: widget.commandAvailability.available
-                    ? () => setState(() {
-                          _selected = true;
-                        })
-                    : null,
+                onPressed: widget.commandAvailability.available ? _expand : null,
                 icon: widget.icon,
               ),
               const SizedBox(width: 8),
@@ -109,7 +131,7 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
         ),
       ),
     );
-    if (!_selected) {
+    if (!isExpanded) {
       if (!widget.commandAvailability.available) {
         return BiocentralTooltip(
           message: widget.commandAvailability.unavailableMessage ?? 'Command currently not available',
@@ -124,9 +146,7 @@ class _BiocentralCommandWidgetState extends State<BiocentralCommandWidget> {
       leading: widget.icon,
       initiallyExpanded: true,
       showTrailingIcon: false,
-      onExpansionChanged: (v) => setState(() {
-        _selected = false;
-      }),
+      onExpansionChanged: (v) => _collapse(),
       children: [
         Text(widget.description),
         const Divider(),


### PR DESCRIPTION
changed padding between command displays to increase offset and make distinction clearer. reduced padding inside command displays to compact individual commands; changed layout of auto accept checkbox to be next to execution button to make more of the command visible and use more horizontal space