### PR TITLE
added plot export for active learning plugin

### DIFF
--- a/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_iteration_result_view.dart
@@ -129,6 +129,7 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
               child: ALPlotView(
                 yLabel: 'Score',
                 data: campaign.iterationResults[_selectedResultIndex].$2,
+                fileNamePrefix: campaign.config.name,
               ),
             ),
             SizedBox(
@@ -175,6 +176,7 @@ class _ALIterationResultViewState extends State<ALIterationResultView>
               child: ALPlotView(
                 yLabel: 'Score',
                 allData: allResults,
+                fileNamePrefix: campaign.config.name,
               ),
             ),
             SizedBox(

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -1,8 +1,10 @@
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
+import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:widgets_to_image/widgets_to_image.dart';
 
 /// A widget that displays a scatter plot visualization of Active Learning results.
 /// The plot shows protein sequences on the x-axis and their corresponding scores on the y-axis.
@@ -15,16 +17,22 @@ class ALPlotView extends StatelessWidget {
   final ActiveLearningIterationResult? data;
   final List<ActiveLearningIterationResult>? allData;
 
+  /// Suggested graph export finelname
+  final String? fileNamePrefix;
+
   final List<ActiveLearningResult> _suggestedResults;
   final List<(int iteration, List<ActiveLearningResult> results)> _iterationData;
 
   /// Cached min/max values for the y-axis range
   final MinMaxValues minMaxValues;
 
+  final WidgetsToImageController _exportController = WidgetsToImageController();
+
   ALPlotView({
     required this.yLabel,
     this.data,
     this.allData,
+    this.fileNamePrefix,
     super.key,
   }) : assert(data != null || allData != null, 'Either data or allData must be provided'),
         _suggestedResults = allData == null ? _buildSuggestedResults(data) : const [],
@@ -68,22 +76,49 @@ class ALPlotView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (allData != null) {
-      return _buildCombined();
+      return _buildCombined(context);
     }
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: Row(
-          children: [
-            _buildScatterPlot(),
-            _buildColorLegend(),
-          ],
-        ),
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.save),
+                tooltip: 'Export plot as PNG',
+                onPressed: () => exportWidgetAsPng(
+                  context: context,
+                  controller: _exportController,
+                  defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_iteration_${data?.iteration}.png',
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+            child: WidgetsToImage(
+              controller: _exportController,
+              child: Container( // used to color background of screenshot the same as application
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      _buildScatterPlot(),
+                      _buildColorLegend(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildCombined() {
+  Widget _buildCombined(BuildContext context) {
     final allResults = _iterationData.expand((e) => e.$2).toList();
     if (allResults.isEmpty) return const SizedBox.shrink();
 
@@ -104,15 +139,42 @@ class ALPlotView extends StatelessWidget {
       }
     }
 
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: Row(
-          children: [
-            Expanded(child: _buildCombinedScatterPlot(spots, spotInfo)),
-            _buildIterationLegend(),
-          ],
-        ),
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.save),
+                tooltip: 'Export plot as PNG',
+                onPressed: () => exportWidgetAsPng(
+                  context: context,
+                  controller: _exportController,
+                  defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_all_iterations.png',
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+            child: WidgetsToImage(
+              controller: _exportController,
+              child: Container( // used to color background of screenshot the same as application
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Expanded(child: _buildCombinedScatterPlot(spots, spotInfo)),
+                      _buildIterationLegend(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -1,9 +1,11 @@
+import 'package:biocentral/sdk/domain/biocentral_project_repository.dart';
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:widgets_to_image/widgets_to_image.dart';
 
 /// A widget that displays a scatter plot visualization of Active Learning results.
@@ -94,7 +96,8 @@ class ALPlotView extends StatelessWidget {
                 icon: const Icon(Icons.save),
                 tooltip: 'Export plot as PNG',
                 onPressed: () => exportWidgetAsPng(
-                  context: context,
+                  messenger: ScaffoldMessenger.of(context),
+                  projectRepository: context.read<BiocentralProjectRepository>(),
                   controller: _exportController,
                   defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_iteration_${data?.iteration}.png',
                 ),
@@ -352,7 +355,8 @@ class _ALCombinedPlotView extends StatelessWidget {
                 icon: const Icon(Icons.save),
                 tooltip: 'Export plot as PNG',
                 onPressed: () => exportWidgetAsPng(
-                  context: context,
+                  messenger: ScaffoldMessenger.of(context),
+                  projectRepository: context.read<BiocentralProjectRepository>(),
                   controller: _exportController,
                   defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_all_iterations.png',
                 ),

--- a/lib/plugins/active_learning/presentation/views/al_plot_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_plot_view.dart
@@ -76,7 +76,12 @@ class ALPlotView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (allData != null) {
-      return _buildCombined(context);
+      return _ALCombinedPlotView(
+        yLabel: yLabel,
+        iterationData: _iterationData,
+        minMaxValues: minMaxValues,
+        fileNamePrefix: fileNamePrefix,
+      );
     }
     return Container(
       color: Theme.of(context).scaffoldBackgroundColor,
@@ -114,181 +119,6 @@ class ALPlotView extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildCombined(BuildContext context) {
-    final allResults = _iterationData.expand((e) => e.$2).toList();
-    if (allResults.isEmpty) return const SizedBox.shrink();
-
-    final List<(int iteration, String entityId, double score)> spotInfo = [];
-    final List<ScatterSpot> spots = [];
-
-    double counterX = 1.0;
-    for (final (iteration, results) in _iterationData) {
-      final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
-      for (final result in results) {
-        spotInfo.add((iteration, result.entityId, result.score.toDouble()));
-        spots.add(ScatterSpot(
-          counterX++,
-          result.score.toDouble(),
-          show: true,
-          dotPainter: FlDotCirclePainter(radius: 8, color: color),
-        ),);
-      }
-    }
-
-    return Container(
-      color: Theme.of(context).scaffoldBackgroundColor,
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              IconButton(
-                icon: const Icon(Icons.save),
-                tooltip: 'Export plot as PNG',
-                onPressed: () => exportWidgetAsPng(
-                  context: context,
-                  controller: _exportController,
-                  defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_all_iterations.png',
-                ),
-              ),
-            ],
-          ),
-          Expanded(
-            child: WidgetsToImage(
-              controller: _exportController,
-              child: Container( // used to color background of screenshot the same as application
-                color: Theme.of(context).scaffoldBackgroundColor,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Row(
-                    children: [
-                      Expanded(child: _buildCombinedScatterPlot(spots, spotInfo)),
-                      _buildIterationLegend(),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCombinedScatterPlot(
-    List<ScatterSpot> spots,
-    List<(int, String, double)> spotInfo,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: ScatterChart(
-        ScatterChartData(
-          titlesData: _buildCombinedTitlesData(spotInfo),
-          gridData: const FlGridData(),
-          scatterSpots: spots,
-          minX: 0,
-          maxX: spots.length.toDouble() + 1,
-          minY: minMaxValues.getMinY,
-          maxY: minMaxValues.getMaxY,
-          borderData: FlBorderData(show: true),
-          scatterTouchData: _buildCombinedTouchData(spotInfo),
-        ),
-      ),
-    );
-  }
-
-  FlTitlesData _buildCombinedTitlesData(List<(int, String, double)> spotInfo) {
-    return FlTitlesData(
-      rightTitles: const AxisTitles(),
-      topTitles: const AxisTitles(
-        axisNameWidget: Text(
-          'All Iterations',
-          style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
-        ),
-      ),
-      leftTitles: AxisTitles(
-        axisNameWidget: Align(
-          alignment: Alignment.bottomCenter,
-          child: Text(yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
-        ),
-        sideTitles: SideTitles(
-          showTitles: true,
-          reservedSize: 50,
-          getTitlesWidget: (value, meta) => Text(
-            value.toStringAsFixed(Constants.maxDoublePrecision),
-            style: const TextStyle(fontSize: 12),
-          ),
-        ),
-      ),
-      bottomTitles: AxisTitles(
-        sideTitles: SideTitles(
-          showTitles: true,
-          interval: 1,
-          reservedSize: 50,
-          getTitlesWidget: (value, meta) {
-            final int index = value.toInt();
-            if (index < 1 || index > spotInfo.length) return const SizedBox.shrink();
-            return RotatedBox(
-              quarterTurns: 3,
-              child: Text(
-                spotInfo[index - 1].$2,
-                style: const TextStyle(fontSize: 12),
-                textAlign: TextAlign.center,
-              ),
-            );
-          },
-        ),
-      ),
-    );
-  }
-
-  ScatterTouchData _buildCombinedTouchData(List<(int, String, double)> spotInfo) {
-    return ScatterTouchData(
-      touchTooltipData: ScatterTouchTooltipData(
-        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
-        getTooltipItems: (ScatterSpot touchedSpot) {
-          final index = touchedSpot.x.toInt() - 1;
-          if (index < 0 || index >= spotInfo.length) return null;
-          final (iteration, entityId, score) = spotInfo[index];
-          return ScatterTooltipItem(
-            'Iteration $iteration\n$entityId\nScore: ${score.toStringAsFixed(Constants.maxDoublePrecision)}',
-            textStyle: const TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 10),
-          );
-        },
-      ),
-      enabled: true,
-    );
-  }
-
-  Widget _buildIterationLegend() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 16),
-      width: 120,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: _iterationData.map((entry) {
-          final (iteration, _) = entry;
-          final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Row(
-              children: [
-                Container(
-                  width: 12,
-                  height: 12,
-                  decoration: BoxDecoration(shape: BoxShape.circle, color: color),
-                ),
-                const SizedBox(width: 8),
-                Text('Iteration $iteration', style: const TextStyle(fontSize: 12)),
-              ],
-            ),
-          );
-        }).toList(),
       ),
     );
   }
@@ -471,6 +301,198 @@ class ALPlotView extends StatelessWidget {
     if (ratio <= 0.6) return BiocentralStyle.alScoreGradientColors[2];
     if (ratio <= 0.8) return BiocentralStyle.alScoreGradientColors[3];
     return BiocentralStyle.alScoreGradientColors[4];
+  }
+}
+
+class _ALCombinedPlotView extends StatelessWidget {
+  final String yLabel;
+  final String? fileNamePrefix;
+  final List<(int iteration, List<ActiveLearningResult> results)> iterationData;
+  final MinMaxValues minMaxValues;
+
+  final WidgetsToImageController _exportController = WidgetsToImageController();
+
+  _ALCombinedPlotView({
+    required this.yLabel,
+    required this.iterationData,
+    required this.minMaxValues,
+    this.fileNamePrefix,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final allResults = iterationData.expand((e) => e.$2).toList();
+    if (allResults.isEmpty) return const SizedBox.shrink();
+
+    final List<(int iteration, String entityId, double score)> spotInfo = [];
+    final List<ScatterSpot> spots = [];
+
+    double counterX = 1.0;
+    for (final (iteration, results) in iterationData) {
+      final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
+      for (final result in results) {
+        spotInfo.add((iteration, result.entityId, result.score.toDouble()));
+        spots.add(ScatterSpot(
+          counterX++,
+          result.score.toDouble(),
+          show: true,
+          dotPainter: FlDotCirclePainter(radius: 8, color: color),
+        ),);
+      }
+    }
+
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.save),
+                tooltip: 'Export plot as PNG',
+                onPressed: () => exportWidgetAsPng(
+                  context: context,
+                  controller: _exportController,
+                  defaultFileName: 'al_scatter_${fileNamePrefix ?? 'plot'}_all_iterations.png',
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+            child: WidgetsToImage(
+              controller: _exportController,
+              child: Container( // used to color background of screenshot the same as application
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Expanded(child: _buildCombinedScatterPlot(spots, spotInfo)),
+                      _buildIterationLegend(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCombinedScatterPlot(
+    List<ScatterSpot> spots,
+    List<(int, String, double)> spotInfo,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: ScatterChart(
+        ScatterChartData(
+          titlesData: _buildCombinedTitlesData(spotInfo),
+          gridData: const FlGridData(),
+          scatterSpots: spots,
+          minX: 0,
+          maxX: spots.length.toDouble() + 1,
+          minY: minMaxValues.getMinY,
+          maxY: minMaxValues.getMaxY,
+          borderData: FlBorderData(show: true),
+          scatterTouchData: _buildCombinedTouchData(spotInfo),
+        ),
+      ),
+    );
+  }
+
+  FlTitlesData _buildCombinedTitlesData(List<(int, String, double)> spotInfo) {
+    return FlTitlesData(
+      rightTitles: const AxisTitles(),
+      topTitles: const AxisTitles(
+        axisNameWidget: Text(
+          'All Iterations',
+          style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+        ),
+      ),
+      leftTitles: AxisTitles(
+        axisNameWidget: Align(
+          alignment: Alignment.bottomCenter,
+          child: Text(yLabel, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+        ),
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 50,
+          getTitlesWidget: (value, meta) => Text(
+            value.toStringAsFixed(Constants.maxDoublePrecision),
+            style: const TextStyle(fontSize: 12),
+          ),
+        ),
+      ),
+      bottomTitles: AxisTitles(
+        sideTitles: SideTitles(
+          showTitles: true,
+          interval: 1,
+          reservedSize: 50,
+          getTitlesWidget: (value, meta) {
+            final int index = value.toInt();
+            if (index < 1 || index > spotInfo.length) return const SizedBox.shrink();
+            return RotatedBox(
+              quarterTurns: 3,
+              child: Text(
+                spotInfo[index - 1].$2,
+                style: const TextStyle(fontSize: 12),
+                textAlign: TextAlign.center,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  ScatterTouchData _buildCombinedTouchData(List<(int, String, double)> spotInfo) {
+    return ScatterTouchData(
+      touchTooltipData: ScatterTouchTooltipData(
+        getTooltipColor: (_) => BiocentralStyle.alTooltipBackground,
+        getTooltipItems: (ScatterSpot touchedSpot) {
+          final index = touchedSpot.x.toInt() - 1;
+          if (index < 0 || index >= spotInfo.length) return null;
+          final (iteration, entityId, score) = spotInfo[index];
+          return ScatterTooltipItem(
+            'Iteration $iteration\n$entityId\nScore: ${score.toStringAsFixed(Constants.maxDoublePrecision)}',
+            textStyle: const TextStyle(color: BiocentralStyle.alTooltipTextColor, fontSize: 10),
+          );
+        },
+      ),
+      enabled: true,
+    );
+  }
+
+  Widget _buildIterationLegend() {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      width: 120,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: iterationData.map((entry) {
+          final (iteration, _) = entry;
+          final color = BiocentralStyle.alIterationColors[iteration % BiocentralStyle.alIterationColors.length];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              children: [
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+                ),
+                const SizedBox(width: 8),
+                Text('Iteration $iteration', style: const TextStyle(fontSize: 12)),
+              ],
+            ),
+          );
+        }).toList(),
+      ),
+    );
   }
 }
 

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -3,10 +3,12 @@ import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
+import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:widgets_to_image/widgets_to_image.dart';
 
 class ALPredictionComparisonView extends StatelessWidget {
   final String yLabel;
@@ -14,13 +16,20 @@ class ALPredictionComparisonView extends StatelessWidget {
   final ActiveLearningIterationResult? result;
   final List<ActiveLearningIterationResult>? allResults;
 
-  const ALPredictionComparisonView({
+  final WidgetsToImageController _exportController = WidgetsToImageController();
+  
+  ALPredictionComparisonView({
     required this.yLabel,
     required this.campaign,
     this.result,
     this.allResults,
     super.key,
   }) : assert(result != null || allResults != null, 'Either result or allResults must be provided');
+
+  String get _defaultFileName {
+    final suffix = result != null ? 'iteration_${result!.iteration}' : 'all_iterations';
+    return 'al_prediction_comparison_${campaign.config.name}_$suffix.png';
+  }
 
   List<(ActiveLearningResult, double, double)> _plottableData(Map<String, Protein> proteinDb) {
     if (allResults != null) {
@@ -64,26 +73,50 @@ class ALPredictionComparisonView extends StatelessWidget {
           title: const Text('Predictions vs. Experiments'),
           leading: const Icon(Icons.compare_arrows),
           children: [
-            SizedBox(
-              height: 500,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 35, 16, 24),
-                child: LineChart(_buildChartData(data)),
-              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.save),
+                  tooltip: 'Export plot as PNG',
+                  onPressed: () => exportWidgetAsPng(
+                    context: context,
+                    controller: _exportController,
+                    defaultFileName: _defaultFileName,
+                  ),
+                ),
+              ],
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  _legendDot(BiocentralStyle.alPredictionLineColor),
-                  const SizedBox(width: 4),
-                  const Text('Prediction', style: TextStyle(fontSize: 12)),
-                  const SizedBox(width: 16),
-                  _legendDot(BiocentralStyle.alExperimentalLineColor),
-                  const SizedBox(width: 4),
-                  const Text('Experiment', style: TextStyle(fontSize: 12)),
-                ],
+            WidgetsToImage(
+              controller: _exportController,
+              child: Container( // used to color background of screenshot the same as application
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: Column(
+                  children: [
+                    SizedBox(
+                      height: 500,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 35, 16, 24),
+                        child: LineChart(_buildChartData(data)),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          _legendDot(BiocentralStyle.alPredictionLineColor),
+                          const SizedBox(width: 4),
+                          const Text('Prediction', style: TextStyle(fontSize: 12)),
+                          const SizedBox(width: 16),
+                          _legendDot(BiocentralStyle.alExperimentalLineColor),
+                          const SizedBox(width: 4),
+                          const Text('Experiment', style: TextStyle(fontSize: 12)),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_comparison_view.dart
@@ -1,6 +1,7 @@
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/domain/biocentral_project_repository.dart';
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral/sdk/util/widget_util.dart';
@@ -80,7 +81,8 @@ class ALPredictionComparisonView extends StatelessWidget {
                   icon: const Icon(Icons.save),
                   tooltip: 'Export plot as PNG',
                   onPressed: () => exportWidgetAsPng(
-                    context: context,
+                    messenger: ScaffoldMessenger.of(context),
+                    projectRepository: context.read<BiocentralProjectRepository>(),
                     controller: _exportController,
                     defaultFileName: _defaultFileName,
                   ),

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -3,10 +3,12 @@ import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
+import 'package:biocentral/sdk/util/widget_util.dart';
 import 'package:biocentral_api/biocentral_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:widgets_to_image/widgets_to_image.dart';
 
 /// Candlestick chart showing the distribution of absolute prediction errors per
 /// iteration. Each candle maps: low=min, open=Q1, close=Q3, high=max.
@@ -16,7 +18,9 @@ class ALPredictionErrorTrendView extends StatelessWidget {
 
   final ALCampaign campaign;
 
-  const ALPredictionErrorTrendView({required this.campaign, super.key});
+  final WidgetsToImageController _exportController = WidgetsToImageController();
+
+  ALPredictionErrorTrendView({required this.campaign, super.key});
 
   /// Returns sorted absolute errors for all suggested proteins in [iterResult]
   /// that have both a numeric prediction and an experimental value.
@@ -78,11 +82,31 @@ class ALPredictionErrorTrendView extends StatelessWidget {
           title: const Text('Prediction Error Distribution'),
           leading: const Icon(Icons.candlestick_chart),
           children: [
-            SizedBox(
-              height: 300,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 24, 32, 16),
-                child: CandlestickChart(_buildChartData(stats)),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.save),
+                  tooltip: 'Export plot as PNG',
+                  onPressed: () => exportWidgetAsPng(
+                    context: context,
+                    controller: _exportController,
+                    defaultFileName: 'al_prediction_error_trend_${campaign.config.name}.png',
+                  ),
+                ),
+              ],
+            ),
+            WidgetsToImage(
+              controller: _exportController,
+              child: Container( // used to color background of screenshot the same as application
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: SizedBox(
+                  height: 300,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 24, 32, 16),
+                    child: CandlestickChart(_buildChartData(stats)),
+                  ),
+                ),
               ),
             ),
           ],

--- a/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
+++ b/lib/plugins/active_learning/presentation/views/al_prediction_error_trend_view.dart
@@ -1,6 +1,7 @@
 import 'package:bio_flutter/bio_flutter.dart';
 import 'package:biocentral/plugins/active_learning/bloc/al_hub_bloc.dart';
 import 'package:biocentral/plugins/active_learning/model/al_campaign.dart';
+import 'package:biocentral/sdk/domain/biocentral_project_repository.dart';
 import 'package:biocentral/sdk/presentation/style/biocentral_style.dart';
 import 'package:biocentral/sdk/util/constants.dart';
 import 'package:biocentral/sdk/util/widget_util.dart';
@@ -89,7 +90,8 @@ class ALPredictionErrorTrendView extends StatelessWidget {
                   icon: const Icon(Icons.save),
                   tooltip: 'Export plot as PNG',
                   onPressed: () => exportWidgetAsPng(
-                    context: context,
+                    messenger: ScaffoldMessenger.of(context),
+                    projectRepository: context.read<BiocentralProjectRepository>(),
                     controller: _exportController,
                     defaultFileName: 'al_prediction_error_trend_${campaign.config.name}.png',
                   ),

--- a/lib/sdk/util/widget_util.dart
+++ b/lib/sdk/util/widget_util.dart
@@ -5,7 +5,6 @@ import 'package:biocentral/sdk/util/constants.dart';
 import 'package:cross_file/cross_file.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:widgets_to_image/widgets_to_image.dart';
 
 extension PaddedWigets on List<Widget> {
@@ -53,35 +52,36 @@ Widget withCondition({required bool condition, required Widget Function() childF
   return Container();
 }
 
-Future<void> exportWidgetAsPng({required BuildContext context, required WidgetsToImageController controller, required String defaultFileName}) async {
+Future<void> exportWidgetAsPng({required ScaffoldMessengerState messenger, required BiocentralProjectRepository projectRepository, required WidgetsToImageController controller, required String defaultFileName}) async {
   final Uint8List? bytes = await controller.capturePng(pixelRatio: 3.0);
-  
-  if (bytes == null) return;
+
+  if (bytes == null) {
+    messenger.showSnackBar(const SnackBar(content: Text('Failed to capture plot image')));
+    return;
+  }
 
   final String? savePath = await FilePicker.platform.saveFile(
     dialogTitle: 'Export plot as PNG',
     fileName: defaultFileName,
   );
-  
-  if (savePath == null) return;
+
+  if (savePath == null) {
+    messenger.showSnackBar(const SnackBar(content: Text('Export canceled')));
+    return;
+  }
 
   final xFile = XFile(savePath);
   final fileName = xFile.name;
   final dirPath = savePath.substring(0, savePath.length - fileName.length - 1);
 
-  if (!context.mounted) return;
-  
-  final projectRepository = context.read<BiocentralProjectRepository>();
   final saveEither = await projectRepository.handleExternalSave(
     fileName: fileName,
     bytesFunction: () async => bytes,
     dirPath: dirPath,
   );
 
-  if (!context.mounted) return;
-  
   saveEither.match(
-    (error) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to export plot: ${error.message}'))),
-    (path) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Plot exported to ${path ?? fileName}'))),
+    (error) => messenger.showSnackBar(SnackBar(content: Text('Failed to export plot: ${error.message}'))),
+    (path) => messenger.showSnackBar(SnackBar(content: Text('Plot exported to ${path ?? fileName}'))),
   );
 }

--- a/lib/sdk/util/widget_util.dart
+++ b/lib/sdk/util/widget_util.dart
@@ -1,5 +1,12 @@
+import 'dart:typed_data';
+
+import 'package:biocentral/sdk/domain/biocentral_project_repository.dart';
 import 'package:biocentral/sdk/util/constants.dart';
+import 'package:cross_file/cross_file.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:widgets_to_image/widgets_to_image.dart';
 
 extension PaddedWigets on List<Widget> {
   List<Widget> withPadding(Padding padding) {
@@ -44,4 +51,37 @@ Widget withCondition({required bool condition, required Widget Function() childF
     return childFunction();
   }
   return Container();
+}
+
+Future<void> exportWidgetAsPng({required BuildContext context, required WidgetsToImageController controller, required String defaultFileName}) async {
+  final Uint8List? bytes = await controller.capturePng(pixelRatio: 3.0);
+  
+  if (bytes == null) return;
+
+  final String? savePath = await FilePicker.platform.saveFile(
+    dialogTitle: 'Export plot as PNG',
+    fileName: defaultFileName,
+  );
+  
+  if (savePath == null) return;
+
+  final xFile = XFile(savePath);
+  final fileName = xFile.name;
+  final dirPath = savePath.substring(0, savePath.length - fileName.length - 1);
+
+  if (!context.mounted) return;
+  
+  final projectRepository = context.read<BiocentralProjectRepository>();
+  final saveEither = await projectRepository.handleExternalSave(
+    fileName: fileName,
+    bytesFunction: () async => bytes,
+    dirPath: dirPath,
+  );
+
+  if (!context.mounted) return;
+  
+  saveEither.match(
+    (error) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to export plot: ${error.message}'))),
+    (path) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Plot exported to ${path ?? fileName}'))),
+  );
 }


### PR DESCRIPTION
added save-as-png button to all plots (works by using existing widgetToImage from embeddings)

replaced al_plot_views scaffold with a container + column to match other plots